### PR TITLE
Use slices & references

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ fn main() {
         None => panic!("Failed to look up .classifier section"),
     };
 
-    let ref prog = &text_scn.data;
+    let prog = &text_scn.data;
 
     // This is our data: a real packet, starting with Ethernet header
     let mut packet = vec![
@@ -409,7 +409,7 @@ fn main() {
     // We must provide the offsets at which the pointers to packet data start
     // and end must be stored: these are the offsets at which the program will
     // load the packet data from the metadata buffer.
-    let mut vm = rbpf::EbpfVmFixedMbuff::new(&prog, 0x40, 0x50);
+    let mut vm = rbpf::EbpfVmFixedMbuff::new(prog, 0x40, 0x50);
 
     // We register a helper function, that can be called by the program, into
     // the VM.

--- a/examples/load_elf.rs
+++ b/examples/load_elf.rs
@@ -65,7 +65,7 @@ fn main() {
         None => panic!("Failed to look up .classifier section"),
     };
 
-    let ref prog = &text_scn.data;
+    let prog = &text_scn.data;
 
     let mut packet1 = vec![
         0x01, 0x23, 0x45, 0x67, 0x89, 0xab,
@@ -111,7 +111,7 @@ fn main() {
         0x64, 0x66, 0x0au8
     ];
 
-    let mut vm = rbpf::EbpfVmFixedMbuff::new(&prog, 0x40, 0x50);
+    let mut vm = rbpf::EbpfVmFixedMbuff::new(prog, 0x40, 0x50);
     vm.register_helper(helpers::BPF_TRACE_PRINTK_IDX, helpers::bpf_trace_printf);
 
     let res = vm.prog_exec(&mut packet1);

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -30,7 +30,7 @@ fn to_json(prog: &[u8]) -> String {
     // `LD_DW_IMM` instructions merged, and name and descriptions of the instructions.
     // If you prefer to use a lower-level representation, use `ebpf::to_insn_vec()` function
     // instead.
-    let insns = disassembler::to_insn_vec(&prog);
+    let insns = disassembler::to_insn_vec(prog);
     let mut json_insns = vec![];
     for insn in insns {
         json_insns.push(object!(
@@ -46,7 +46,7 @@ fn to_json(prog: &[u8]) -> String {
                 // number is negative. When values takes more than 32 bits with `lddw`, the cast
                 // has no effect and the complete value is printed anyway.
                 "imm"  => format!("{:#x}", insn.imm as i32), // => insn.imm,
-                "desc" => format!("{}",    insn.desc)
+                "desc" => insn.desc
             )
         );
     }
@@ -73,7 +73,7 @@ fn main() {
         None => panic!("Failed to look up .classifier section"),
     };
 
-    let ref prog = &text_scn.data;
+    let prog = &text_scn.data;
 
     println!("{}", to_json(&prog));
 }

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -24,7 +24,7 @@ use rbpf::disassembler;
 // * Remove the "desc" (description) attributes from the output.
 // * Print integers as integers, and not as strings containing their hexadecimal representation
 //   (just replace the relevant `format!()` calls by the commented values.
-fn to_json(prog: &std::vec::Vec<u8>) -> String {
+fn to_json(prog: &[u8]) -> String {
 
     // This call returns a high-level representation of the instructions, with the two parts of
     // `LD_DW_IMM` instructions merged, and name and descriptions of the instructions.

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -9,7 +9,6 @@
 //! for example to disassemble the code into a human-readable format.
 
 use ebpf;
-use std;
 
 #[inline]
 fn alu_imm_str(name: &str, insn: &ebpf::Insn) -> String {
@@ -146,7 +145,7 @@ pub struct HLInsn {
 ///     },
 /// ]);
 /// ```
-pub fn to_insn_vec(prog: &std::vec::Vec<u8>) -> std::vec::Vec<HLInsn> {
+pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
     if prog.len() % ebpf::INSN_SIZE != 0 {
         panic!("[Disassembler] Error: eBPF program length must be a multiple of {:?} octets",
                ebpf::INSN_SIZE);
@@ -330,7 +329,7 @@ pub fn to_insn_vec(prog: &std::vec::Vec<u8>) -> std::vec::Vec<HLInsn> {
 /// neg64 r8
 /// exit
 /// ```
-pub fn disassemble(prog: &std::vec::Vec<u8>) {
+pub fn disassemble(prog: &[u8]) {
     if prog.len() % ebpf::INSN_SIZE != 0 {
         panic!("[Disassembler] Error: eBPF program length must be a multiple of {:?} octets",
                ebpf::INSN_SIZE);

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -413,7 +413,7 @@ pub fn get_insn(prog: &[u8], idx: usize) -> Insn {
         panic!("Error: cannot reach instruction at index {:?} in program containing {:?} bytes",
                idx, prog.len());
     }
-    let insn = Insn {
+    Insn {
         opc:  prog[INSN_SIZE * idx],
         dst:  prog[INSN_SIZE * idx + 1] & 0x0f,
         src: (prog[INSN_SIZE * idx + 1] & 0xf0) >> 4,
@@ -423,8 +423,7 @@ pub fn get_insn(prog: &[u8], idx: usize) -> Insn {
         imm: unsafe {
             let x = prog.as_ptr().offset((INSN_SIZE * idx + 4) as isize) as *const i32; *x
         },
-    };
-    insn
+    }
 }
 
 /// Return a vector of `struct Insn` built from a program.

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -17,8 +17,6 @@
 //! <https://www.kernel.org/doc/Documentation/networking/filter.txt>, or for a shorter version of
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
-use std;
-
 /// Maximum number of instructions in an eBPF program.
 pub const PROG_MAX_INSNS: usize = 4096;
 /// Size of an eBPF instructions, in bytes.
@@ -407,7 +405,7 @@ pub struct Insn {
 ///     ];
 /// let insn = ebpf::get_insn(&prog, 1);
 /// ```
-pub fn get_insn(prog: &std::vec::Vec<u8>, idx: usize) -> Insn {
+pub fn get_insn(prog: &[u8], idx: usize) -> Insn {
     // This guard should not be needed in most cases, since the verifier already checks the program
     // size, and indexes should be fine in the interpreter/JIT. But this function is publicly
     // available and user can call it with any `idx`, so we have to check anyway.
@@ -473,7 +471,7 @@ pub fn get_insn(prog: &std::vec::Vec<u8>, idx: usize) -> Insn {
 ///     },
 /// ]);
 /// ```
-pub fn to_insn_vec(prog: &std::vec::Vec<u8>) -> std::vec::Vec<Insn> {
+pub fn to_insn_vec(prog: &[u8]) -> Vec<Insn> {
     if prog.len() % INSN_SIZE != 0 {
         panic!("Error: eBPF program length must be a multiple of {:?} octets",
                INSN_SIZE);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -714,10 +714,10 @@ impl<'a> JitMemory<'a> {
                     // For JIT, helpers in use MUST be registered at compile time. They can be
                     // updated later, but not created after compiling (we need the address of the
                     // helper function in the JIT-compiled program).
-                    if let Some(_) = helpers.get(&(insn.imm as u32)) {
+                    if let Some(helper) = helpers.get(&(insn.imm as u32)) {
                         // We reserve RCX for shifts
                         emit_mov(self, R9, RCX);
-                        emit_call(self, helpers[&(insn.imm as u32)] as i64);
+                        emit_call(self, *helper as i64);
                     } else {
                         panic!("[JIT] Error: unknown helper function (id: {:#x})",
                                insn.imm as u32);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -425,9 +425,9 @@ struct Jump {
 struct JitMemory<'a> {
     contents:        &'a mut [u8],
     offset:          usize,
-    pc_locs:         std::vec::Vec<usize>,
+    pc_locs:         Vec<usize>,
     special_targets: HashMap<isize, usize>,
-    jumps:           std::vec::Vec<Jump>,
+    jumps:           Vec<Jump>,
 }
 
 impl<'a> JitMemory<'a> {
@@ -451,7 +451,7 @@ impl<'a> JitMemory<'a> {
         }
     }
 
-    fn jit_compile(&mut self, prog: &std::vec::Vec<u8>, use_mbuff: bool, update_data_ptr: bool,
+    fn jit_compile(&mut self, prog: &[u8], use_mbuff: bool, update_data_ptr: bool,
                    helpers: &HashMap<u32, fn (u64, u64, u64, u64, u64) -> u64>) {
         emit_push(self, RBP);
         emit_push(self, RBX);
@@ -832,7 +832,7 @@ impl<'a> std::fmt::Debug for JitMemory<'a> {
 }
 
 // In the end, this is the only thing we export
-pub fn compile(prog: &std::vec::Vec<u8>,
+pub fn compile(prog: &[u8],
                helpers: &HashMap<u32, fn (u64, u64, u64, u64, u64) -> u64>,
                use_mbuff: bool, update_data_ptr: bool)
     -> (unsafe fn(*mut u8, usize, *mut u8, usize, usize, usize) -> u64) {

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -24,9 +24,8 @@
 
 
 use ebpf;
-use std;
 
-fn check_prog_len(prog: &std::vec::Vec<u8>) {
+fn check_prog_len(prog: &[u8]) {
     if prog.len() % ebpf::INSN_SIZE != 0 {
         panic!("[Verifier] Error: eBPF program length must be a multiple of {:?} octets",
                ebpf::INSN_SIZE);
@@ -58,7 +57,7 @@ fn check_imm_endian(insn: &ebpf::Insn, insn_ptr: usize) {
     }
 }
 
-fn check_load_dw(prog: &std::vec::Vec<u8>, insn_ptr: usize) {
+fn check_load_dw(prog: &[u8], insn_ptr: usize) {
     // We know we can reach next insn since we enforce an EXIT insn at the end of program, while
     // this function should be called only for LD_DW insn, that cannot be last in program.
     let next_insn = ebpf::get_insn(prog, insn_ptr + 1);
@@ -68,7 +67,7 @@ fn check_load_dw(prog: &std::vec::Vec<u8>, insn_ptr: usize) {
 
 }
 
-fn check_jmp_offset(prog: &std::vec::Vec<u8>, insn_ptr: usize) {
+fn check_jmp_offset(prog: &[u8], insn_ptr: usize) {
     let insn = ebpf::get_insn(prog, insn_ptr);
     if insn.off == -1 {
         panic!("[Verifier] Error: infinite loop (insn #{:?})", insn_ptr);
@@ -102,7 +101,7 @@ fn check_registers(insn: &ebpf::Insn, store: bool, insn_ptr: usize) {
     }
 }
 
-pub fn check(prog: &std::vec::Vec<u8>) -> bool {
+pub fn check(prog: &[u8]) -> bool {
     check_prog_len(prog);
 
     let mut insn_ptr:usize = 0;

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -108,7 +108,7 @@ fn test_vm_block_port() {
     //     None => panic!("Failed to look up .classifier section"),
     // };
     //
-    // let ref prog = &text_scn.data;
+    // let prog = &text_scn.data;
     // ---
 
     let prog = vec![
@@ -189,7 +189,7 @@ fn test_jit_block_port() {
     //     None => panic!("Failed to look up .classifier section"),
     // };
     //
-    // let ref prog = &text_scn.data;
+    // let prog = &text_scn.data;
     // ---
 
     let prog = vec![
@@ -263,11 +263,11 @@ fn test_vm_mbuff() {
         0x69, 0x10, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     ];
-    let mut mem = vec![
+    let mem = vec![
         0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd
     ];
 
-    let mut mbuff = vec![0u8; 32];
+    let mbuff = vec![0u8; 32];
     unsafe {
         let mut data     = mbuff.as_ptr().offset(8)  as *mut u64;
         let mut data_end = mbuff.as_ptr().offset(24) as *mut u64;
@@ -276,7 +276,7 @@ fn test_vm_mbuff() {
     }
 
     let vm = rbpf::EbpfVmMbuff::new(&prog);
-    assert_eq!(vm.prog_exec(&mut mem, &mut mbuff), 0x2211);
+    assert_eq!(vm.prog_exec(&mem, &mbuff), 0x2211);
 }
 
 // Program and memory come from uBPF test ldxh.


### PR DESCRIPTION
As promised here are a few Rust-y details to your code.
I ran [cargo-clippy](https://github.com/Manishearth/rust-clippy) against the code and fixed nearly all of the warnings.
A list of some of the changes:

1. Slice instead of Vec. [`ptr_arg`](https://github.com/Manishearth/rust-clippy/wiki#ptr_arg)
2. Don't re-borrow slices. [`needless_borrow`](https://github.com/Manishearth/rust-clippy/wiki#needless_borrow)
3. Useless use of vec. [`useless_vec`](https://github.com/Manishearth/rust-clippy/wiki#useless_vec)
4. …and a few more. [Full log of clippy against the master branch](https://gist.github.com/badboy/dee55394f010597413cd9ae806da0953)

I even changed `&mut Vec` to `&mut []` (i.e. a mutable vector to a mutable slice, as afaik it should not be possibleto resize the passed array, but only modify it).
Tests still run just fine.
If above assumption is not valid, I need to switch it back.

I'd be happy to answer questions regarding any of the changes.