### PR TITLE
fix clippy error: cast to more strict alignment, warning: not consumed copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ include = [
 combine = "2.1.1"
 libc = "0.2.0"
 time = "0.1"
+byteorder = "1.2.1"
 
 [dev-dependencies]
 

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -18,6 +18,9 @@
 //! <https://www.kernel.org/doc/Documentation/networking/filter.txt>, or for a shorter version of
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
+extern crate byteorder;
+use self::byteorder::{ByteOrder, LittleEndian};
+
 /// Maximum number of instructions in an eBPF program.
 pub const PROG_MAX_INSNS: usize = 4096;
 /// Size of an eBPF instructions, in bytes.
@@ -513,12 +516,8 @@ pub fn get_insn(prog: &[u8], idx: usize) -> Insn {
         opc:  prog[INSN_SIZE * idx],
         dst:  prog[INSN_SIZE * idx + 1] & 0x0f,
         src: (prog[INSN_SIZE * idx + 1] & 0xf0) >> 4,
-        off: unsafe {
-            let x = prog.as_ptr().offset((INSN_SIZE * idx + 2) as isize) as *const i16; *x
-        },
-        imm: unsafe {
-            let x = prog.as_ptr().offset((INSN_SIZE * idx + 4) as isize) as *const i32; *x
-        },
+        off: LittleEndian::read_i16(&prog[(INSN_SIZE * idx + 2) .. ]),
+        imm: LittleEndian::read_i32(&prog[(INSN_SIZE * idx + 4) .. ]),
     }
 }
 

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -18,8 +18,7 @@
 //! <https://www.kernel.org/doc/Documentation/networking/filter.txt>, or for a shorter version of
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
-extern crate byteorder;
-use self::byteorder::{ByteOrder, LittleEndian};
+use byteorder::{ByteOrder, LittleEndian};
 
 /// Maximum number of instructions in an eBPF program.
 pub const PROG_MAX_INSNS: usize = 4096;

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -255,7 +255,7 @@ fn set_anchor(jit: &mut JitMemory, target: isize) {
 
 // Load [src + offset] into dst
 #[inline]
-fn emit_load(jit: &mut JitMemory, size: OperandSize, src: u8, dst: u8, offset: i32) {
+fn emit_load(jit: &mut JitMemory, size: &OperandSize, src: u8, dst: u8, offset: i32) {
     let data = match size {
         OperandSize::S64 => 1,
         _ => 0
@@ -297,7 +297,7 @@ fn emit_load_imm(jit: &mut JitMemory, dst: u8, imm: i64) {
 
 // Store register src to [dst + offset]
 #[inline]
-fn emit_store(jit: &mut JitMemory, size: OperandSize, src: u8, dst: u8, offset: i32) {
+fn emit_store(jit: &mut JitMemory, size: &OperandSize, src: u8, dst: u8, offset: i32) {
     match size {
         OperandSize::S16 => emit1(jit, 0x66), // 16-bit override
         _ => {},
@@ -325,7 +325,7 @@ fn emit_store(jit: &mut JitMemory, size: OperandSize, src: u8, dst: u8, offset: 
 
 // Store immediate to [dst + offset]
 #[inline]
-fn emit_store_imm32(jit: &mut JitMemory, size: OperandSize, dst: u8, offset: i32, imm: i32) {
+fn emit_store_imm32(jit: &mut JitMemory, size: &OperandSize, dst: u8, offset: i32, imm: i32) {
     match size {
         OperandSize::S16 => emit1(jit, 0x66), // 16-bit override
         _ => {},
@@ -485,12 +485,12 @@ impl<'a> JitMemory<'a> {
                 // We have a fixed (simulated) mbuff: update mem and mem_end offset values in it.
                 // Store mem at mbuff + mem_offset. Trash R8.
                 emit_alu64(self, 0x01, RDI, R8);                // add mbuff to mem_offset in R8
-                emit_store(self, OperandSize::S64, RDX, R8, 0); // set mem at mbuff + mem_offset
+                emit_store(self, &OperandSize::S64, RDX, R8, 0); // set mem at mbuff + mem_offset
                 // Store mem_end at mbuff + mem_end_offset. Trash R9.
-                emit_load(self, OperandSize::S64, RDX, R8, 0);  // load mem into R8
+                emit_load(self, &OperandSize::S64, RDX, R8, 0);  // load mem into R8
                 emit_alu64(self, 0x01, RCX, R8);                // add mem_len to mem (= mem_end)
                 emit_alu64(self, 0x01, RDI, R9);                // add mbuff to mem_end_offset
-                emit_store(self, OperandSize::S64, R8, R9, 0);  // store mem_end
+                emit_store(self, &OperandSize::S64, R8, R9, 0);  // store mem_end
 
                 // Move rdi into register 1
                 if map_register(1) != RDI {
@@ -522,32 +522,32 @@ impl<'a> JitMemory<'a> {
                 // BPF_LD class
                 // R10 is a constant pointer to mem.
                 ebpf::LD_ABS_B   =>
-                    emit_load(self, OperandSize::S8,  R10, RAX, insn.imm),
+                    emit_load(self, &OperandSize::S8,  R10, RAX, insn.imm),
                 ebpf::LD_ABS_H   =>
-                    emit_load(self, OperandSize::S16, R10, RAX, insn.imm),
+                    emit_load(self, &OperandSize::S16, R10, RAX, insn.imm),
                 ebpf::LD_ABS_W   =>
-                    emit_load(self, OperandSize::S32, R10, RAX, insn.imm),
+                    emit_load(self, &OperandSize::S32, R10, RAX, insn.imm),
                 ebpf::LD_ABS_DW  =>
-                    emit_load(self, OperandSize::S64, R10, RAX, insn.imm),
+                    emit_load(self, &OperandSize::S64, R10, RAX, insn.imm),
                 ebpf::LD_IND_B   => {
                     emit_mov(self, R10, R11);                              // load mem into R11
                     emit_alu64(self, 0x01, src, R11);                      // add src to R11
-                    emit_load(self, OperandSize::S8,  R11, RAX, insn.imm); // ld R0, mem[src+imm]
+                    emit_load(self, &OperandSize::S8,  R11, RAX, insn.imm); // ld R0, mem[src+imm]
                 },
                 ebpf::LD_IND_H   => {
                     emit_mov(self, R10, R11);                              // load mem into R11
                     emit_alu64(self, 0x01, src, R11);                      // add src to R11
-                    emit_load(self, OperandSize::S16, R11, RAX, insn.imm); // ld R0, mem[src+imm]
+                    emit_load(self, &OperandSize::S16, R11, RAX, insn.imm); // ld R0, mem[src+imm]
                 },
                 ebpf::LD_IND_W   => {
                     emit_mov(self, R10, R11);                              // load mem into R11
                     emit_alu64(self, 0x01, src, R11);                      // add src to R11
-                    emit_load(self, OperandSize::S32, R11, RAX, insn.imm); // ld R0, mem[src+imm]
+                    emit_load(self, &OperandSize::S32, R11, RAX, insn.imm); // ld R0, mem[src+imm]
                 },
                 ebpf::LD_IND_DW  => {
                     emit_mov(self, R10, R11);                              // load mem into R11
                     emit_alu64(self, 0x01, src, R11);                      // add src to R11
-                    emit_load(self, OperandSize::S64, R11, RAX, insn.imm); // ld R0, mem[src+imm]
+                    emit_load(self, &OperandSize::S64, R11, RAX, insn.imm); // ld R0, mem[src+imm]
                 },
 
                 ebpf::LD_DW_IMM  => {
@@ -559,33 +559,33 @@ impl<'a> JitMemory<'a> {
 
                 // BPF_LDX class
                 ebpf::LD_B_REG   =>
-                    emit_load(self, OperandSize::S8,  src, dst, insn.off as i32),
+                    emit_load(self, &OperandSize::S8,  src, dst, insn.off as i32),
                 ebpf::LD_H_REG   =>
-                    emit_load(self, OperandSize::S16, src, dst, insn.off as i32),
+                    emit_load(self, &OperandSize::S16, src, dst, insn.off as i32),
                 ebpf::LD_W_REG   =>
-                    emit_load(self, OperandSize::S32, src, dst, insn.off as i32),
+                    emit_load(self, &OperandSize::S32, src, dst, insn.off as i32),
                 ebpf::LD_DW_REG  =>
-                    emit_load(self, OperandSize::S64, src, dst, insn.off as i32),
+                    emit_load(self, &OperandSize::S64, src, dst, insn.off as i32),
 
                 // BPF_ST class
                 ebpf::ST_B_IMM   =>
-                    emit_store_imm32(self, OperandSize::S8,  dst, insn.off as i32, insn.imm),
+                    emit_store_imm32(self, &OperandSize::S8,  dst, insn.off as i32, insn.imm),
                 ebpf::ST_H_IMM   =>
-                    emit_store_imm32(self, OperandSize::S16, dst, insn.off as i32, insn.imm),
+                    emit_store_imm32(self, &OperandSize::S16, dst, insn.off as i32, insn.imm),
                 ebpf::ST_W_IMM   =>
-                    emit_store_imm32(self, OperandSize::S32, dst, insn.off as i32, insn.imm),
+                    emit_store_imm32(self, &OperandSize::S32, dst, insn.off as i32, insn.imm),
                 ebpf::ST_DW_IMM  =>
-                    emit_store_imm32(self, OperandSize::S64, dst, insn.off as i32, insn.imm),
+                    emit_store_imm32(self, &OperandSize::S64, dst, insn.off as i32, insn.imm),
 
                 // BPF_STX class
                 ebpf::ST_B_REG   =>
-                    emit_store(self, OperandSize::S8,  src, dst, insn.off as i32),
+                    emit_store(self, &OperandSize::S8,  src, dst, insn.off as i32),
                 ebpf::ST_H_REG   =>
-                    emit_store(self, OperandSize::S16, src, dst, insn.off as i32),
+                    emit_store(self, &OperandSize::S16, src, dst, insn.off as i32),
                 ebpf::ST_W_REG   =>
-                    emit_store(self, OperandSize::S32, src, dst, insn.off as i32),
+                    emit_store(self, &OperandSize::S32, src, dst, insn.off as i32),
                 ebpf::ST_DW_REG  =>
-                    emit_store(self, OperandSize::S64, src, dst, insn.off as i32),
+                    emit_store(self, &OperandSize::S64, src, dst, insn.off as i32),
                 ebpf::ST_W_XADD  => unimplemented!(),
                 ebpf::ST_DW_XADD => unimplemented!(),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@
 use std::u32;
 use std::collections::HashMap;
 
+extern crate byteorder;
+use self::byteorder::{ByteOrder, LittleEndian};
+
 extern crate combine;
 extern crate time;
 
@@ -885,12 +888,8 @@ impl<'a> EbpfVmFixedMbuff<'a> {
             panic!("Error: buffer too small ({:?}), cannot use data_offset {:?} and data_end_offset {:?}",
             l, self.mbuff.data_offset, self.mbuff.data_end_offset);
         }
-        unsafe {
-            let mut data     = self.mbuff.buffer.as_ptr().offset(self.mbuff.data_offset as isize)     as *mut u64;
-            let mut data_end = self.mbuff.buffer.as_ptr().offset(self.mbuff.data_end_offset as isize) as *mut u64;
-            *data     = mem.as_ptr() as u64;
-            *data_end = mem.as_ptr() as u64 + mem.len() as u64;
-        }
+        LittleEndian::write_u64(&mut self.mbuff.buffer[(self.mbuff.data_offset) .. ], mem.as_ptr() as u64);
+        LittleEndian::write_u64(&mut self.mbuff.buffer[(self.mbuff.data_end_offset) .. ], mem.as_ptr() as u64 + mem.len() as u64);
         self.parent.prog_exec(mem, &self.mbuff.buffer)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,13 @@
 
 #![cfg_attr(feature = "cargo-clippy", allow(cast_lossless, doc_markdown, match_same_arms, unreadable_literal))]
 
-use std::u32;
-use std::collections::HashMap;
-
 extern crate byteorder;
-use self::byteorder::{ByteOrder, LittleEndian};
-
 extern crate combine;
 extern crate time;
+
+use std::u32;
+use std::collections::HashMap;
+use byteorder::{ByteOrder, LittleEndian};
 
 pub mod assembler;
 pub mod disassembler;


### PR DESCRIPTION
Interested in using rBPF for a project I'm working on so fixed a couple of clippy errors/warnings.  If this project is still active and these changes are approved would like to fix more

- pulled byteorder dependency back in to avoid unsafe code and to fix clippy casting errors
- removed copy of operand that was not consumed