### PR TITLE
Cargo.toml: upgrade to version 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 # Project metadata
 name = "rbpf"
-version = "0.0.3"
+version = "0.1.0"
 authors = ["Quentin Monnet <quentin.monnet@netronome.com>"]
 
 # Additional metadata for packaging

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ file:
 
 ```toml
 [dependencies]
-rbpf = "0.0.2"
+rbpf = "0.1.0"
 ```
 
 You can also use the development version from this GitHub repository. This
@@ -360,7 +360,7 @@ to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-rbpf = "0.0.2"
+rbpf = "0.1.0"
 elf = "0.0.10"
 ```
 


### PR DESCRIPTION
Bump version number to release a new crate version.

We're not-so-stable yet, especially with all the changes we had other the last days, so it seems early to change the major version. On the other hand, we got many changes since the previous version of the crate: assembler, disassembler, Rust API to build programs; custom verifiers; error handling; many fixes, etc. So we'll bump the second digit and tag version 0.1.0.