### PR TITLE
fix how the disassembler handles offsets

### DIFF
--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -31,17 +31,29 @@ fn byteswap_str(name: &str, insn: &ebpf::Insn) -> String {
 
 #[inline]
 fn ld_st_imm_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} [r{}+{:#x}], {:#x}", name, insn.dst, insn.off, insn.imm)
+    if insn.off >= 0 {
+        format!("{} [r{}+{:#x}], {:#x}", name, insn.dst, insn.off, insn.imm)
+    } else {
+        format!("{} [r{}-{:#x}], {:#x}", name, insn.dst, -insn.off, insn.imm)
+    }
 }
 
 #[inline]
 fn ld_reg_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} r{}, [r{}+{:#x}]", name, insn.dst, insn.src, insn.off)
+    if insn.off >= 0 {
+        format!("{} r{}, [r{}+{:#x}]", name, insn.dst, insn.src, insn.off)
+    } else {
+        format!("{} r{}, [r{}-{:#x}]", name, insn.dst, insn.src, -insn.off)
+    }
 }
 
 #[inline]
 fn st_reg_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} [r{}+{:#x}], r{}", name, insn.dst, insn.off, insn.src)
+    if insn.off >= 0 {
+        format!("{} [r{}+{:#x}], r{}", name, insn.dst, insn.off, insn.src)
+    } else {
+        format!("{} [r{}-{:#x}], r{}", name, insn.dst, -insn.off, insn.src)
+    }
 }
 
 #[inline]
@@ -56,12 +68,20 @@ fn ldind_str(name: &str, insn: &ebpf::Insn) -> String {
 
 #[inline]
 fn jmp_imm_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} r{}, {:#x}, {:+#x}", name, insn.dst, insn.imm, insn.off)
+    if insn.off >= 0 {
+        format!("{} r{}, {:#x}, +{:#x}", name, insn.dst, insn.imm, insn.off)
+    } else {
+        format!("{} r{}, {:#x}, -{:#x}", name, insn.dst, insn.imm, -insn.off)
+    }
 }
 
 #[inline]
 fn jmp_reg_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} r{}, r{}, {:+#x}", name, insn.dst, insn.src, insn.off)
+    if insn.off >= 0 {
+        format!("{} r{}, r{}, +{:#x}", name, insn.dst, insn.src, insn.off)
+    } else {
+        format!("{} r{}, r{}, -{:#x}", name, insn.dst, insn.src, -insn.off)
+    }
 }
 
 /// High-level representation of an eBPF instruction.

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -263,7 +263,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
             ebpf::ARSH64_REG => { name = "arsh64"; desc = alu_reg_str(name, &insn); },
 
             // BPF_JMP class
-            ebpf::JA         => { name = "ja";   desc = format!("{} {:+#x}", name, insn.off); },
+            ebpf::JA         => { name = "ja";   desc = if insn.off >= 0 { format!("{} +{:#x}", name, insn.off) } else { format!("{} -{:#x}", name, -insn.off) } },
             ebpf::JEQ_IMM    => { name = "jeq";  desc = jmp_imm_str(name, &insn); },
             ebpf::JEQ_REG    => { name = "jeq";  desc = jmp_reg_str(name, &insn); },
             ebpf::JGT_IMM    => { name = "jgt";  desc = jmp_imm_str(name, &insn); },

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -837,7 +837,7 @@ impl<'a> JitMemory<'a> {
             //         Err(_) => -1
             //     }
             pc as i64 // Just to prevent warnings
-        };
+        }
         emit_mov(self, RCX, RDI); // muldivmod stored pc in RCX
         emit_call(self, log as usize);
         emit_load_imm(self, map_register(0), -1);


### PR DESCRIPTION
As explained in the commit message of 038ddf7:

> https://doc.rust-lang.org/std/fmt/trait.LowerHex.html says "For primitive signed integers (i8 to i128, and isize), negative values are formatted as the two’s complement representation."
> 
> As such, we can't rely on Rust's "+" formatting flag when writing instruction offsets.