### PR TITLE
src: Address newer reports from cargo-clippy

### DIFF
--- a/examples/load_elf.rs
+++ b/examples/load_elf.rs
@@ -52,7 +52,7 @@ fn main() {
     let filename = "examples/load_elf__block_a_port.o";
 
     let path = PathBuf::from(filename);
-    let file = match elf::File::open_path(&path) {
+    let file = match elf::File::open_path(path) {
         Ok(f) => f,
         Err(e) => panic!("Error: {:?}", e),
     };
@@ -112,7 +112,7 @@ fn main() {
     vm.register_helper(helpers::BPF_TRACE_PRINTK_IDX, helpers::bpf_trace_printf).unwrap();
 
     let res = vm.execute_program(packet1).unwrap();
-    println!("Packet #1, program returned: {:?} ({:#x})", res, res);
+    println!("Packet #1, program returned: {res:?} ({res:#x})");
     assert_eq!(res, 0xffffffff);
 
     #[cfg(not(windows))]
@@ -120,7 +120,7 @@ fn main() {
         vm.jit_compile().unwrap();
 
         let res = unsafe { vm.execute_program_jit(packet2).unwrap() };
-        println!("Packet #2, program returned: {:?} ({:#x})", res, res);
+        println!("Packet #2, program returned: {res:?} ({res:#x})");
         assert_eq!(res, 0);
     }
 

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -58,7 +58,7 @@ fn main() {
     let filename = "examples/load_elf__block_a_port.o";
 
     let path = PathBuf::from(filename);
-    let file = match elf::File::open_path(&path) {
+    let file = match elf::File::open_path(path) {
         Ok(f) => f,
         Err(e) => panic!("Error: {:?}", e),
     };

--- a/src/asm_parser.rs
+++ b/src/asm_parser.rs
@@ -90,8 +90,8 @@ fn instruction<I>(input: I) -> ParseResult<Instruction, I>
 
 fn format_info(info: &Info<char, &str>) -> String {
     match *info {
-        Info::Token(x) => format!("{:?}", x),
-        Info::Range(x) => format!("{:?}", x),
+        Info::Token(x) => format!("{x:?}"),
+        Info::Range(x) => format!("{x:?}"),
         Info::Owned(ref x) => x.clone(),
         Info::Borrowed(x) => x.to_string(),
     }
@@ -102,7 +102,7 @@ fn format_error(error: &Error<char, &str>) -> String {
         Error::Unexpected(ref x) => format!("unexpected {}", format_info(x)),
         Error::Expected(ref x) => format!("expected {}", format_info(x)),
         Error::Message(ref x) => format_info(x),
-        Error::Other(ref x) => format!("{:?}", x),
+        Error::Other(ref x) => format!("{x:?}"),
     }
 }
 

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -8,75 +8,75 @@ use ebpf;
 
 #[inline]
 fn alu_imm_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} r{}, {:#x}", name, insn.dst, insn.imm)
+    format!("{name} r{}, {:#x}", insn.dst, insn.imm)
 }
 
 #[inline]
 fn alu_reg_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} r{}, r{}", name, insn.dst, insn.src)
+    format!("{name} r{}, r{}", insn.dst, insn.src)
 }
 
 #[inline]
 fn byteswap_str(name: &str, insn: &ebpf::Insn) -> String {
     match insn.imm {
         16 | 32 | 64 => {},
-        _ => println!("[Disassembler] Warning: Invalid offset value for {} insn", name)
+        _ => println!("[Disassembler] Warning: Invalid offset value for {name} insn")
     }
-    format!("{}{} r{}", name, insn.imm, insn.dst)
+    format!("{name}{} r{}", insn.imm, insn.dst)
 }
 
 #[inline]
 fn ld_st_imm_str(name: &str, insn: &ebpf::Insn) -> String {
     if insn.off >= 0 {
-        format!("{} [r{}+{:#x}], {:#x}", name, insn.dst, insn.off, insn.imm)
+        format!("{name} [r{}+{:#x}], {:#x}", insn.dst, insn.off, insn.imm)
     } else {
-        format!("{} [r{}-{:#x}], {:#x}", name, insn.dst, -insn.off, insn.imm)
+        format!("{name} [r{}-{:#x}], {:#x}", insn.dst, -insn.off, insn.imm)
     }
 }
 
 #[inline]
 fn ld_reg_str(name: &str, insn: &ebpf::Insn) -> String {
     if insn.off >= 0 {
-        format!("{} r{}, [r{}+{:#x}]", name, insn.dst, insn.src, insn.off)
+        format!("{name} r{}, [r{}+{:#x}]", insn.dst, insn.src, insn.off)
     } else {
-        format!("{} r{}, [r{}-{:#x}]", name, insn.dst, insn.src, -insn.off)
+        format!("{name} r{}, [r{}-{:#x}]", insn.dst, insn.src, -insn.off)
     }
 }
 
 #[inline]
 fn st_reg_str(name: &str, insn: &ebpf::Insn) -> String {
     if insn.off >= 0 {
-        format!("{} [r{}+{:#x}], r{}", name, insn.dst, insn.off, insn.src)
+        format!("{name} [r{}+{:#x}], r{}", insn.dst, insn.off, insn.src)
     } else {
-        format!("{} [r{}-{:#x}], r{}", name, insn.dst, -insn.off, insn.src)
+        format!("{name} [r{}-{:#x}], r{}", insn.dst, -insn.off, insn.src)
     }
 }
 
 #[inline]
 fn ldabs_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} {:#x}", name, insn.imm)
+    format!("{name} {:#x}", insn.imm)
 }
 
 #[inline]
 fn ldind_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} r{}, {:#x}", name, insn.src, insn.imm)
+    format!("{name} r{}, {:#x}", insn.src, insn.imm)
 }
 
 #[inline]
 fn jmp_imm_str(name: &str, insn: &ebpf::Insn) -> String {
     if insn.off >= 0 {
-        format!("{} r{}, {:#x}, +{:#x}", name, insn.dst, insn.imm, insn.off)
+        format!("{name} r{}, {:#x}, +{:#x}", insn.dst, insn.imm, insn.off)
     } else {
-        format!("{} r{}, {:#x}, -{:#x}", name, insn.dst, insn.imm, -insn.off)
+        format!("{name} r{}, {:#x}, -{:#x}", insn.dst, insn.imm, -insn.off)
     }
 }
 
 #[inline]
 fn jmp_reg_str(name: &str, insn: &ebpf::Insn) -> String {
     if insn.off >= 0 {
-        format!("{} r{}, r{}, +{:#x}", name, insn.dst, insn.src, insn.off)
+        format!("{name} r{}, r{}, +{:#x}", insn.dst, insn.src, insn.off)
     } else {
-        format!("{} r{}, r{}, -{:#x}", name, insn.dst, insn.src, -insn.off)
+        format!("{name} r{}, r{}, -{:#x}", insn.dst, insn.src, -insn.off)
     }
 }
 
@@ -199,7 +199,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
                 insn_ptr += 1;
                 let next_insn = ebpf::get_insn(prog, insn_ptr);
                 imm = ((insn.imm as u32) as u64 + ((next_insn.imm as u64) << 32)) as i64;
-                name = "lddw"; desc = format!("{} r{:}, {:#x}", name, insn.dst, imm);
+                name = "lddw"; desc = format!("{name} r{:}, {imm:#x}", insn.dst);
             },
 
             // BPF_LDX class
@@ -239,7 +239,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
             ebpf::LSH32_REG  => { name = "lsh32";  desc = alu_reg_str(name, &insn);  },
             ebpf::RSH32_IMM  => { name = "rsh32";  desc = alu_imm_str(name, &insn);  },
             ebpf::RSH32_REG  => { name = "rsh32";  desc = alu_reg_str(name, &insn);  },
-            ebpf::NEG32      => { name = "neg32";  desc = format!("{} r{:}", name, insn.dst); },
+            ebpf::NEG32      => { name = "neg32";  desc = format!("{name} r{:}", insn.dst); },
             ebpf::MOD32_IMM  => { name = "mod32";  desc = alu_imm_str(name, &insn);  },
             ebpf::MOD32_REG  => { name = "mod32";  desc = alu_reg_str(name, &insn);  },
             ebpf::XOR32_IMM  => { name = "xor32";  desc = alu_imm_str(name, &insn);  },
@@ -268,7 +268,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
             ebpf::LSH64_REG  => { name = "lsh64";  desc = alu_reg_str(name, &insn); },
             ebpf::RSH64_IMM  => { name = "rsh64";  desc = alu_imm_str(name, &insn); },
             ebpf::RSH64_REG  => { name = "rsh64";  desc = alu_reg_str(name, &insn); },
-            ebpf::NEG64      => { name = "neg64";  desc = format!("{} r{:}", name, insn.dst); },
+            ebpf::NEG64      => { name = "neg64";  desc = format!("{name} r{:}", insn.dst); },
             ebpf::MOD64_IMM  => { name = "mod64";  desc = alu_imm_str(name, &insn); },
             ebpf::MOD64_REG  => { name = "mod64";  desc = alu_reg_str(name, &insn); },
             ebpf::XOR64_IMM  => { name = "xor64";  desc = alu_imm_str(name, &insn); },
@@ -279,7 +279,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
             ebpf::ARSH64_REG => { name = "arsh64"; desc = alu_reg_str(name, &insn); },
 
             // BPF_JMP class
-            ebpf::JA         => { name = "ja";   desc = if insn.off >= 0 { format!("{} +{:#x}", name, insn.off) } else { format!("{} -{:#x}", name, -insn.off) } },
+            ebpf::JA         => { name = "ja";   desc = if insn.off >= 0 { format!("{name} +{:#x}", insn.off) } else { format!("{name} -{:#x}", -insn.off) } },
             ebpf::JEQ_IMM    => { name = "jeq";  desc = jmp_imm_str(name, &insn); },
             ebpf::JEQ_REG    => { name = "jeq";  desc = jmp_reg_str(name, &insn); },
             ebpf::JGT_IMM    => { name = "jgt";  desc = jmp_imm_str(name, &insn); },
@@ -302,7 +302,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
             ebpf::JSLT_REG   => { name = "jslt"; desc = jmp_reg_str(name, &insn); },
             ebpf::JSLE_IMM   => { name = "jsle"; desc = jmp_imm_str(name, &insn); },
             ebpf::JSLE_REG   => { name = "jsle"; desc = jmp_reg_str(name, &insn); },
-            ebpf::CALL       => { name = "call"; desc = format!("{} {:#x}", name, insn.imm); },
+            ebpf::CALL       => { name = "call"; desc = format!("{name} {:#x}", insn.imm); },
             ebpf::TAIL_CALL  => { name = "tail_call"; desc = name.to_string(); },
             ebpf::EXIT       => { name = "exit";      desc = name.to_string(); },
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -95,7 +95,7 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 #[allow(dead_code)]
 #[allow(unused_variables)]
 pub fn bpf_trace_printf (unused1: u64, unused2: u64, arg3: u64, arg4: u64, arg5: u64) -> u64 {
-    println!("bpf_trace_printf: {:#x}, {:#x}, {:#x}", arg3, arg4, arg5);
+    println!("bpf_trace_printf: {arg3:#x}, {arg4:#x}, {arg5:#x}");
     let size_arg = | x | {
         if x == 0 {
             1

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -80,7 +80,7 @@ macro_rules! emit_bytes {
         assert!($jit.offset + size <= $jit.contents.len());
         unsafe {
             let mut ptr = $jit.contents.as_ptr().add($jit.offset) as *mut $t;
-            *ptr = $data as $t;
+            *ptr = $data;
         }
         $jit.offset += size;
     }}
@@ -791,8 +791,8 @@ impl<'a> JitMemory<'a> {
 
                 _                => {
                     Err(Error::new(ErrorKind::Other,
-                                   format!("[JIT] Error: unknown eBPF opcode {:#2x} (insn #{:?})",
-                                           insn.opc, insn_ptr)))?;
+                                   format!("[JIT] Error: unknown eBPF opcode {:#2x} (insn #{insn_ptr:?})",
+                                           insn.opc)))?;
                 },
             }
 
@@ -881,7 +881,7 @@ impl<'a> std::fmt::Debug for JitMemory<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FormatterError> {
         fmt.write_str("JIT contents: [")?;
         for i in self.contents as &[u8] {
-            fmt.write_fmt(format_args!(" {:#04x},", i))?;
+            fmt.write_fmt(format_args!(" {i:#04x},"))?;
         };
         fmt.write_str(" ] | ")?;
         fmt.debug_struct("JIT state")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ impl<'a> EbpfVmMbuff<'a> {
                 ebpf::LD_ABS_DW  => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + (insn.imm as u32) as u64) as *const u64;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x as u64
+                    *x
                 },
                 ebpf::LD_IND_B   => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + reg[_src] + (insn.imm as u32) as u64) as *const u8;
@@ -352,7 +352,7 @@ impl<'a> EbpfVmMbuff<'a> {
                 ebpf::LD_IND_DW  => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + reg[_src] + (insn.imm as u32) as u64) as *const u64;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x as u64
+                    *x
                 },
 
                 ebpf::LD_DW_IMM  => {
@@ -384,7 +384,7 @@ impl<'a> EbpfVmMbuff<'a> {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_src] as *const u8).offset(insn.off as isize) as *const u64;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x as u64
+                    *x
                 },
 
                 // BPF_ST class
@@ -434,7 +434,7 @@ impl<'a> EbpfVmMbuff<'a> {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_dst] as *const u8).offset(insn.off as isize) as *mut u64;
                     check_mem_store(x as u64, 8, insn_ptr)?;
-                    *x = reg[_src] as u64;
+                    *x = reg[_src];
                 },
                 ebpf::ST_W_XADD  => unimplemented!(),
                 ebpf::ST_DW_XADD => unimplemented!(),

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -166,7 +166,7 @@ fn test_vm_block_port() {
     vm.register_helper(helpers::BPF_TRACE_PRINTK_IDX, helpers::bpf_trace_printf).unwrap();
 
     let res = vm.execute_program(packet).unwrap();
-    println!("Program returned: {:?} ({:#x})", res, res);
+    println!("Program returned: {res:?} ({res:#x})");
     assert_eq!(res, 0xffffffff);
 }
 
@@ -250,7 +250,7 @@ fn test_jit_block_port() {
 
     unsafe {
         let res = vm.execute_program_jit(packet).unwrap();
-        println!("Program returned: {:?} ({:#x})", res, res);
+        println!("Program returned: {res:?} ({res:#x})");
         assert_eq!(res, 0xffffffff);
     }
 }


### PR DESCRIPTION
We addressed reports from Clippy in previous commits, see for example commit 153995b3a367 ("Let cargo-clippy lint the code"). But it looks like the latest version of the linter applies more checks, and the GitHub workflow in the CI is raising warnings. Let's address all these reports.