### PR TITLE
ci: Enable exit-not-last test in conformance tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,9 +14,8 @@ jobs:
       # Exclude features not supported by rbpf yet.
       # 32-bit jump - https://github.com/qmonnet/rbpf/issues/47
       # atomic operations - https://github.com/qmonnet/rbpf/issues/47
-      # exit-not-last - https://github.com/qmonnet/rbpf/issues/62
       # mem-len - Tests assume r2 contains the length of the memory.
-      KNOWN_FAILURES: "(j.*32|lock|by-zero|exit-not-last|mem-len)"
+      KNOWN_FAILURES: "(j.*32|lock|by-zero|mem-len)"
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This test was disabled because of #62, but the issue has been solved. We can now run this test in the CI.