### PR TITLE
Capture code coverage and upload

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,3 +67,18 @@ jobs:
           --plugin_path /rbpf/target/release/examples/rbpf_plugin \
           --exclude_regex "${{ env.KNOWN_FAILURES }}"  \
           --plugin_options "--jit" || true
+
+      - name: Install development tools
+        uses: taiki-e/install-action@v1.14.2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate coverage report
+        run: |
+          cargo llvm-cov --lcov --all --all-features --all-targets > lcov.info
+
+      - name: Upload coverage to coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov.info


### PR DESCRIPTION
Capture code coverage for the tests run during CI/CD.
Use the https://github.com/taiki-e/cargo-llvm-cov tools chain to convert coverage into lcov-based report.
Upload report to a free (for OSS) site that permits tracking code coverage data over time.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>