### PR TITLE
README.md adjustments (and a few more minor things)

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,10 @@ in some places instead of the Rusty look the author would like it to have. So
 feedback (or PRs) are welcome, including about ways you might see to take
 better advantage of Rust features.
 
+Note that the project expects new commits to be covered by the
+[Developer's Certificate of Origin](https://wiki.linuxfoundation.org/dco).
+When contributing Pull Requests, please sign off your commits accordingly.
+
 ## Questions / Answers
 
 ### Why implementing an eBPF virtual machine in Rust?

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ use rbpf::helpers;
 fn main() {
     // Load a program from an ELF file, e.g. compiled from C to eBPF with
     // clang/LLVM. Some minor modification to the bytecode may be required.
-    let filename = "my_ebpf_object_file.o";
+    let filename = "examples/load_elf__block_a_port.o";
 
     let path = PathBuf::from(filename);
     let file = match elf::File::open_path(&path) {

--- a/README.md
+++ b/README.md
@@ -305,12 +305,17 @@ fn main() {
     // directly reads from packet data)
     let mut vm = rbpf::EbpfVmRaw::new(Some(prog)).unwrap();
 
-    // This time we JIT-compile the program.
-    vm.jit_compile().unwrap();
+    #[cfg(windows)] {
+        assert_eq!(vm.execute_program(mem).unwrap(), 0x11);
+    }
+    #[cfg(not(windows))] {
+        // This time we JIT-compile the program.
+        vm.jit_compile().unwrap();
 
-    // Then we execute it. For this kind of VM, a reference to the packet data
-    // must be passed to the function that executes the program.
-    unsafe { assert_eq!(vm.execute_program_jit(mem).unwrap(), 0x11); }
+        // Then we execute it. For this kind of VM, a reference to the packet
+        // data must be passed to the function that executes the program.
+        unsafe { assert_eq!(vm.execute_program_jit(mem).unwrap(), 0x11); }
+    }
 }
 ```
 ### Using a metadata buffer
@@ -346,12 +351,19 @@ fn main() {
     // This eBPF VM is for program that use a metadata buffer.
     let mut vm = rbpf::EbpfVmMbuff::new(Some(prog)).unwrap();
 
-    // Here again we JIT-compile the program.
-    vm.jit_compile().unwrap();
+    #[cfg(windows)] {
+        assert_eq!(vm.execute_program(mem, mbuff).unwrap(), 0x2211);
+    }
+    #[cfg(not(windows))] {
+        // Here again we JIT-compile the program.
+        vm.jit_compile().unwrap();
 
-    // Here we must provide both a reference to the packet data, and to the
-    // metadata buffer we use.
-    unsafe { assert_eq!(vm.execute_program_jit(mem, mbuff).unwrap(), 0x2211); }
+        // Here we must provide both a reference to the packet data, and to the
+        // metadata buffer we use.
+        unsafe {
+            assert_eq!(vm.execute_program_jit(mem, mbuff).unwrap(), 0x2211);
+        }
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Rust (user-space) virtual machine for eBPF
 
 [![Build Status](https://github.com/qmonnet/rbpf/actions/workflows/test.yaml/badge.svg)](https://github.com/qmonnet/rbpf/actions/workflows/test.yaml)
 [![Build status](https://ci.appveyor.com/api/projects/status/ia74coeuhxtrcvsk/branch/master?svg=true)](https://ci.appveyor.com/project/qmonnet/rbpf/branch/master)
+[![Coverage Status](https://coveralls.io/repos/github/qmonnet/rbpf/badge.svg?branch=master)](https://coveralls.io/github/qmonnet/rbpf?branch=master)
 [![Crates.io](https://img.shields.io/crates/v/rbpf.svg)](https://crates.io/crates/rbpf)
 
 * [Description](#description)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ pub fn new(prog: &'a [u8]) -> Result<EbpfVmNoData<'a>, Error>
 
 This is used to create a new instance of a VM. The return type is dependent of
 the struct from which the function is called. For instance,
-`rbpf::EbpfVmRaw::new(my_program)` would return an instance of `struct
+`rbpf::EbpfVmRaw::new(Some(my_program))` would return an instance of `struct
 rbpf::EbpfVmRaw` (wrapped in a `Result`). When a program is loaded, it is
 checked with a very simple verifier (nothing close to the one for Linux
 kernel). Users are also able to replace it with a custom verifier.
@@ -431,7 +431,7 @@ fn main() {
     // We must provide the offsets at which the pointers to packet data start
     // and end must be stored: these are the offsets at which the program will
     // load the packet data from the metadata buffer.
-    let mut vm = rbpf::EbpfVmFixedMbuff::new(prog, 0x40, 0x50).unwrap();
+    let mut vm = rbpf::EbpfVmFixedMbuff::new(Some(prog), 0x40, 0x50).unwrap();
 
     // We register a helper function, that can be called by the program, into
     // the VM.

--- a/examples/rbpf_plugin.rs
+++ b/examples/rbpf_plugin.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 // Helper function used by https://github.com/Alan-Jowett/bpf_conformance/blob/main/tests/call_unwind_fail.data
 fn _unwind(a: u64, _b: u64, _c: u64, _d: u64, _e: u64) -> u64
 {
-    return a;
+    a
 }
 
 // This is a plugin for the bpf_conformance test suite (https://github.com/Alan-Jowett/bpf_conformance)
@@ -20,9 +20,9 @@ fn main() {
     let mut memory_text = String::new();
 
     args.remove(0);
-    
+
     // Memory is always the first argument.
-    if args.len() > 0 {
+    if !args.is_empty() {
         memory_text = args[0].clone();
         // Strip whitespace
         memory_text.retain(|c| !c.is_whitespace());
@@ -30,7 +30,7 @@ fn main() {
     }
 
     // Process the rest of the arguments.
-    while args.len() > 0 {
+    while !args.is_empty() {
         match args[0].as_str() {
             "--help" => { 
                 println!("Usage: rbpf_plugin [memory] < program");
@@ -51,7 +51,7 @@ fn main() {
                     return;
                 }
                 args.remove(0);
-                if args.len() > 0 {
+                if !args.is_empty() {
                     program_text = args[0].clone();
                     args.remove(0);
                 }
@@ -61,7 +61,7 @@ fn main() {
         args.remove(0);
     }
 
-    if program_text.len() == 0 {
+    if program_text.is_empty() {
         // Read program text from stdin
         std::io::stdin().read_to_string(&mut program_text).unwrap();
     }
@@ -77,10 +77,10 @@ fn main() {
 
     // Create rbpf vm
     let mut vm = rbpf::EbpfVmRaw::new(Some(&bytecode)).unwrap();
-    
+
     // Register the helper function used by call_unwind_fail.data test.
     vm.register_helper(5, _unwind).unwrap();
-    
+
     let result : u64;
     if jit {
         #[cfg(windows)] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/qmonnet/rbpf/master/misc/rbpf.png",
        html_favicon_url = "https://raw.githubusercontent.com/qmonnet/rbpf/master/misc/rbpf.ico")]
 
+// Test examples from README.md as part as doc tests.
+#![doc = include_str!("../README.md")]
+
 #![warn(missing_docs)]
 // There are unused mut warnings due to unsafe code.
 #![allow(unused_mut)]


### PR DESCRIPTION
- README.md: Use Option to pass programs when building new VMs in examples
- README.md: Fix example by using an existing object file
- README.md: Adjust Windows execution for examples with JIT compiler 
- src/lib.rs: Make "cargo test" run on examples from README.md
- README.md: Add coverage status badge
- README.md: State DCO requirement explicitly
- examples/rbpf_plugin.rs: Fix minor reports from clippy
