### PR TITLE
deps: update time crate version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ include = [
 
 combine = "2.5"
 libc = "0.2"
-time = "0.1"
+time = "0.2"
 byteorder = "1.2"
 
 [dev-dependencies]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -47,6 +47,7 @@ pub const BPF_KTIME_GETNS_IDX: u32 = 5;
 /// ```
 #[allow(dead_code)]
 #[allow(unused_variables)]
+#[allow(deprecated)]
 pub fn bpf_time_getns (unused1: u64, unused2: u64, unused3: u64, unused4: u64, unused5: u64) -> u64 {
     time::precise_time_ns()
 }


### PR DESCRIPTION
The time crate version used in rbpf [has a security issue](https://rustsec.org/advisories/RUSTSEC-2020-0071) (though the use of it in this library is secure). Update the time crate version to make the audits of the crates which depend on rbpf succeed.