### PR TITLE
Cargo.toml: Disable debug assertions for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,9 @@ byteorder = "1.2"
 elf = "0.0.10"
 json = "0.11"
 hex = "0.4.3"
+
+[profile.dev]
+
+# TODO: Find a way to re-enable debug assertions by addressing the reports for
+# misaligned pointer dereferences - see issue #77.
+debug-assertions = false


### PR DESCRIPTION
Recent versions of the toolchain introduced an assert to panic on unaligned pointer dereferences. We do have some unaligned accesses in our test suite, and rbpf has been supporting them so far.

As a quick fix, disable debug assertions in the tests. We want to re-enable them as soon as possible, once we have a solution to avoid these panics.
