### PR TITLE
jit.rs: When emitting bytes, mark writing as unaligned

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -79,7 +79,7 @@ macro_rules! emit_bytes {
         assert!($jit.offset + size <= $jit.contents.len());
         unsafe {
             let mut ptr = $jit.contents.as_ptr().add($jit.offset) as *mut $t;
-            *ptr = $data;
+            ptr.write_unaligned($data);
         }
         $jit.offset += size;
     }}


### PR DESCRIPTION
To avoid cargo printing debug assertions about misaligned pointer dereferences when JIT-compiling programs for the tests, fix the way we write the bytes to explicitly tell rustc we may have misaligned accesses. No functional change.

Related: #77
