### PR TITLE
Fix alignment issues (and a test-only buffer overflow)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,3 @@ byteorder = "1.2"
 elf = "0.0.10"
 json = "0.11"
 hex = "0.4.3"
-
-[profile.dev]
-
-# TODO: Find a way to re-enable debug assertions by addressing the reports for
-# misaligned pointer dereferences - see issue #77.
-debug-assertions = false

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -203,8 +203,8 @@ pub fn sqrti (arg1: u64, unused2: u64, unused3: u64, unused4: u64, unused5: u64)
 /// ```
 /// use rbpf::helpers;
 ///
-/// let foo = "This is a string.".as_ptr() as u64;
-/// let bar = "This is another sting.".as_ptr() as u64;
+/// let foo = "This is a string.\0".as_ptr() as u64;
+/// let bar = "This is another sting.\0".as_ptr() as u64;
 ///
 /// assert!(helpers::strcmp(foo, foo, 0, 0, 0) == 0);
 /// assert!(helpers::strcmp(foo, bar, 0, 0, 0) != 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,42 +324,42 @@ impl<'a> EbpfVmMbuff<'a> {
                 ebpf::LD_ABS_B   => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + (insn.imm as u32) as u64) as *const u8;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x as u64
+                    x.read_unaligned() as u64
                 },
                 ebpf::LD_ABS_H   => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + (insn.imm as u32) as u64) as *const u16;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x as u64
+                    x.read_unaligned() as u64
                 },
                 ebpf::LD_ABS_W   => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + (insn.imm as u32) as u64) as *const u32;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x as u64
+                    x.read_unaligned() as u64
                 },
                 ebpf::LD_ABS_DW  => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + (insn.imm as u32) as u64) as *const u64;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x
+                    x.read_unaligned()
                 },
                 ebpf::LD_IND_B   => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + reg[_src] + (insn.imm as u32) as u64) as *const u8;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x as u64
+                    x.read_unaligned() as u64
                 },
                 ebpf::LD_IND_H   => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + reg[_src] + (insn.imm as u32) as u64) as *const u16;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x as u64
+                    x.read_unaligned() as u64
                 },
                 ebpf::LD_IND_W   => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + reg[_src] + (insn.imm as u32) as u64) as *const u32;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x as u64
+                    x.read_unaligned() as u64
                 },
                 ebpf::LD_IND_DW  => reg[0] = unsafe {
                     let x = (mem.as_ptr() as u64 + reg[_src] + (insn.imm as u32) as u64) as *const u64;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x
+                    x.read_unaligned()
                 },
 
                 ebpf::LD_DW_IMM  => {
@@ -373,75 +373,75 @@ impl<'a> EbpfVmMbuff<'a> {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_src] as *const u8).offset(insn.off as isize) as *const u8;
                     check_mem_load(x as u64, 1, insn_ptr)?;
-                    *x as u64
+                    x.read_unaligned() as u64
                 },
                 ebpf::LD_H_REG   => reg[_dst] = unsafe {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_src] as *const u8).offset(insn.off as isize) as *const u16;
                     check_mem_load(x as u64, 2, insn_ptr)?;
-                    *x as u64
+                    x.read_unaligned() as u64
                 },
                 ebpf::LD_W_REG   => reg[_dst] = unsafe {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_src] as *const u8).offset(insn.off as isize) as *const u32;
                     check_mem_load(x as u64, 4, insn_ptr)?;
-                    *x as u64
+                    x.read_unaligned() as u64
                 },
                 ebpf::LD_DW_REG  => reg[_dst] = unsafe {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_src] as *const u8).offset(insn.off as isize) as *const u64;
                     check_mem_load(x as u64, 8, insn_ptr)?;
-                    *x
+                    x.read_unaligned()
                 },
 
                 // BPF_ST class
                 ebpf::ST_B_IMM   => unsafe {
                     let x = (reg[_dst] as *const u8).offset(insn.off as isize) as *mut u8;
                     check_mem_store(x as u64, 1, insn_ptr)?;
-                    *x = insn.imm as u8;
+                    x.write_unaligned(insn.imm as u8);
                 },
                 ebpf::ST_H_IMM   => unsafe {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_dst] as *const u8).offset(insn.off as isize) as *mut u16;
                     check_mem_store(x as u64, 2, insn_ptr)?;
-                    *x = insn.imm as u16;
+                    x.write_unaligned(insn.imm as u16);
                 },
                 ebpf::ST_W_IMM   => unsafe {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_dst] as *const u8).offset(insn.off as isize) as *mut u32;
                     check_mem_store(x as u64, 4, insn_ptr)?;
-                    *x = insn.imm as u32;
+                    x.write_unaligned(insn.imm as u32);
                 },
                 ebpf::ST_DW_IMM  => unsafe {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_dst] as *const u8).offset(insn.off as isize) as *mut u64;
                     check_mem_store(x as u64, 8, insn_ptr)?;
-                    *x = insn.imm as u64;
+                    x.write_unaligned(insn.imm as u64);
                 },
 
                 // BPF_STX class
                 ebpf::ST_B_REG   => unsafe {
                     let x = (reg[_dst] as *const u8).offset(insn.off as isize) as *mut u8;
                     check_mem_store(x as u64, 1, insn_ptr)?;
-                    *x = reg[_src] as u8;
+                    x.write_unaligned(reg[_src] as u8);
                 },
                 ebpf::ST_H_REG   => unsafe {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_dst] as *const u8).offset(insn.off as isize) as *mut u16;
                     check_mem_store(x as u64, 2, insn_ptr)?;
-                    *x = reg[_src] as u16;
+                    x.write_unaligned(reg[_src] as u16);
                 },
                 ebpf::ST_W_REG   => unsafe {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_dst] as *const u8).offset(insn.off as isize) as *mut u32;
                     check_mem_store(x as u64, 4, insn_ptr)?;
-                    *x = reg[_src] as u32;
+                    x.write_unaligned(reg[_src] as u32);
                 },
                 ebpf::ST_DW_REG  => unsafe {
                     #[allow(cast_ptr_alignment)]
                     let x = (reg[_dst] as *const u8).offset(insn.off as isize) as *mut u64;
                     check_mem_store(x as u64, 8, insn_ptr)?;
-                    *x = reg[_src];
+                    x.write_unaligned(reg[_src]);
                 },
                 ebpf::ST_W_XADD  => unimplemented!(),
                 ebpf::ST_DW_XADD => unimplemented!(),

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -273,8 +273,8 @@ fn test_vm_mbuff() {
     unsafe {
         let mut data     = mbuff.as_ptr().offset(8)  as *mut u64;
         let mut data_end = mbuff.as_ptr().offset(24) as *mut u64;
-        *data     = mem.as_ptr() as u64;
-        *data_end = mem.as_ptr() as u64 + mem.len() as u64;
+        data.write_unaligned(mem.as_ptr() as u64);
+        data_end.write_unaligned(mem.as_ptr() as u64 + mem.len() as u64);
     }
 
     let vm = rbpf::EbpfVmMbuff::new(Some(prog)).unwrap();


### PR DESCRIPTION
Fixes https://github.com/qmonnet/rbpf/issues/77

I ran this to find all the issues fixed here:
```
RUSTDOCFLAGS=-Zsanitizer=address ASAN_OPTIONS=detect_leaks=0 RUSTFLAGS=-Zsanitizer=address cargo +nightly test --target=x86_64-unknown-linux-gnu
```

ASan is still grumpy because `JitMemory` leaks the `contents` allocation. This is probably fine in practice I think because there won't be more than one JIT in a process? But if you want you could also add a `Drop` impl.

It would probably be good to use the above invocation when doing stuff in CI, but I'm awful with GitHub actions so I'll leave that to you if you want to do it.