### PR TITLE
Rename `master` into `main`, bump crate version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 branches:
   only:
-    - master
+    - main
 os:
   - Visual Studio 2015
 clone_depth: 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 # Project metadata
 name = "rbpf"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Quentin <quentin@isovalent.com>"]
 
 # Additional metadata for packaging

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ file:
 
 ```toml
 [dependencies]
-rbpf = "0.1.0"
+rbpf = "0.2.0"
 ```
 
 You can also use the development version from this GitHub repository. This
@@ -377,7 +377,7 @@ to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-rbpf = "0.1.0"
+rbpf = "0.2.0"
 elf = "0.0.10"
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 Rust (user-space) virtual machine for eBPF
 
 [![Build Status](https://github.com/qmonnet/rbpf/actions/workflows/test.yaml/badge.svg)](https://github.com/qmonnet/rbpf/actions/workflows/test.yaml)
-[![Build status](https://ci.appveyor.com/api/projects/status/ia74coeuhxtrcvsk/branch/master?svg=true)](https://ci.appveyor.com/project/qmonnet/rbpf/branch/master)
-[![Coverage Status](https://coveralls.io/repos/github/qmonnet/rbpf/badge.svg?branch=master)](https://coveralls.io/github/qmonnet/rbpf?branch=master)
+[![Build status](https://ci.appveyor.com/api/projects/status/ia74coeuhxtrcvsk/branch/main?svg=true)](https://ci.appveyor.com/project/qmonnet/rbpf/branch/main)
+[![Coverage Status](https://coveralls.io/repos/github/qmonnet/rbpf/badge.svg?branch=main)](https://coveralls.io/github/qmonnet/rbpf?branch=main)
 [![Crates.io](https://img.shields.io/crates/v/rbpf.svg)](https://crates.io/crates/rbpf)
 
 * [Description](#description)
@@ -82,8 +82,8 @@ The API is pretty well documented inside the source code. You should also be
 able to access [an online version of the documentation from
 here](https://docs.rs/rbpf/), automatically generated from the
 [crates.io](https://crates.io/crates/rbpf) version (may not be up-to-date with
-master branch). [Examples](../../tree/master/examples) and [unit
-tests](../../tree/master/tests) should also prove helpful. Here is a summary of
+the main branch). [Examples](../../tree/main/examples) and [unit
+tests](../../tree/main/tests) should also prove helpful. Here is a summary of
 how to use the crate.
 
 Here are the steps to follow to run an eBPF program with rbpf:
@@ -676,8 +676,8 @@ integration with other projects, the rbpf crate is distributed under the terms
 of both the MIT license and the Apache License (Version 2.0).
 
 See
-[LICENSE-APACHE](https://github.com/qmonnet/rbpf/blob/master/LICENSE-APACHE)
-and [LICENSE-MIT](https://github.com/qmonnet/rbpf/blob/master/LICENSE-MIT) for
+[LICENSE-APACHE](https://github.com/qmonnet/rbpf/blob/main/LICENSE-APACHE)
+and [LICENSE-MIT](https://github.com/qmonnet/rbpf/blob/main/LICENSE-MIT) for
 details.
 
 ## Inspired by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@
 // Copyright 2023 Isovalent, Inc. <quentin@isovalent.com>
 
 //! Virtual machine and JIT compiler for eBPF programs.
-#![doc(html_logo_url = "https://raw.githubusercontent.com/qmonnet/rbpf/master/misc/rbpf.png",
-       html_favicon_url = "https://raw.githubusercontent.com/qmonnet/rbpf/master/misc/rbpf.ico")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/qmonnet/rbpf/main/misc/rbpf.png",
+       html_favicon_url = "https://raw.githubusercontent.com/qmonnet/rbpf/main/misc/rbpf.ico")]
 
 // Test examples from README.md as part as doc tests.
 #![doc = include_str!("../README.md")]


### PR DESCRIPTION
- ci: Remove empty workflow file
- rbpf: Rename "master" branch into "main" everywhere in the repo
- Cargo.toml,README.md: Bump version to 0.2.0
