### PR TITLE
src/jit.rs: Fix offset when skipping insns for handling divisions by 0

### DIFF
--- a/tests/ubpf_jit_x86_64.rs
+++ b/tests/ubpf_jit_x86_64.rs
@@ -392,6 +392,33 @@ fn test_jit_div64_reg() {
     unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0x300000000); }
 }
 
+// For some register numbers, we don't emit the same instructions for handling divisions by zero,
+// which means we don't use the same offset to skip these instructions when the divisor is not
+// zero. We've had a regression because of this before, make sure we test it.
+#[test]
+fn test_jit_div32_highreg() {
+    let prog = assemble("
+        mov r0, 2
+        mov r7, 4
+        div32 r7, r0
+        exit").unwrap();
+    let mut vm = rbpf::EbpfVmNoData::new(Some(&prog)).unwrap();
+    vm.jit_compile().unwrap();
+    unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0x2); }
+}
+
+#[test]
+fn test_jit_div64_highreg() {
+    let prog = assemble("
+        mov r0, 2
+        mov r7, 4
+        div r7, r0
+        exit").unwrap();
+    let mut vm = rbpf::EbpfVmNoData::new(Some(&prog)).unwrap();
+    vm.jit_compile().unwrap();
+    unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0x2); }
+}
+
 #[test]
 fn test_jit_early_exit() {
     let prog = assemble("


### PR DESCRIPTION
When dividing by the content of a register, we have a specific case to handle divisions by zero. When the denominator is not 0, we skip the related instructions by emitted a near jump with the relevant offset.

However, this offset was incorrect. We accounted for two instructions: a 2-byte long XOR of the destination register with itself to set it to 0, and a 5-byte long jump. The former may in fact emit 3 bytes under certain condition, depending on the destination in use. For example, when dividing from r7, we emit 3 bytes, and the fixed offset of 7 bytes we used is incorrect, and triggers a segfault.

To fix this, let's add a check to determine the offset value we should use. We also add related tests to make sure we don't regress on this in the future.

Closes: https://github.com/qmonnet/rbpf/issues/88
