### PR TITLE
src/interpreter.rs: Fix arithmetic left/right shift implementation (mask offset)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -286,8 +286,8 @@ pub fn execute_program(prog_: Option<&[u8]>, mem: &[u8], mbuff: &[u8], helpers: 
             ebpf::XOR64_REG  => reg[_dst] ^= reg[_src],
             ebpf::MOV64_IMM  => reg[_dst] =  insn.imm  as u64,
             ebpf::MOV64_REG  => reg[_dst] =  reg[_src],
-            ebpf::ARSH64_IMM => reg[_dst] = (reg[_dst] as i64 >> insn.imm)  as u64,
-            ebpf::ARSH64_REG => reg[_dst] = (reg[_dst] as i64 >> reg[_src]) as u64,
+            ebpf::ARSH64_IMM => reg[_dst] = (reg[_dst] as i64 >> (insn.imm as u64 & SHIFT_MASK_64))  as u64,
+            ebpf::ARSH64_REG => reg[_dst] = (reg[_dst] as i64 >> (reg[_src] as u64 & SHIFT_MASK_64)) as u64,
 
             // BPF_JMP class
             // TODO: check this actually works as expected for signed / unsigned ops


### PR DESCRIPTION
Fix #101 

We mask the mask offset for arithmetic shifts operaitons. The current version of the BPF Instruction Set Specification specifies that "Shift operations use a mask of 0x3F (63) for 64-bit operations and 0x1F (31) for 32-bit operations" [0].

[0]: https://www.ietf.org/archive/id/draft-thaler-bpf-isa-02.html#section-3.1-2.2.16.1.1