### PR TITLE
.appveyor.yml: Use 'stable' channel for Rust version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ platform:
 environment:
   matrix:
     - TOOLCHAIN_VERSION: 14.0
-      RUST: 1.64.0
+      RUST: 1.76.0
     - TOOLCHAIN_VERSION: 14.0
       RUST: beta
     - TOOLCHAIN_VERSION: 14.0


### PR DESCRIPTION
Don't pin to a specific version in Appveyor. This is less deterministic for the tests, but because we don't run them often anyway we want to use up-to-date versions when we do. And this is consistent with the Linux workflows.