### PR TITLE
src: Remove unused imports raised by linter

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -19,7 +19,6 @@
 extern crate libc;
 
 use std::u64;
-use time;
 
 // Helpers associated to kernel helpers
 // See also linux/include/uapi/linux/bpf.h in Linux kernel sources.

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -5,7 +5,6 @@
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 //      (Translation to Rust, MetaBuff addition)
 
-use std;
 use std::mem;
 use std::collections::HashMap;
 use std::fmt::Formatter;


### PR DESCRIPTION
I observed the following warning while running the tests, let's address
them:

    warning: the item `time` is imported redundantly
      --> src/helpers.rs:22:5
       |
    22 | use time;
       |     ^^^^
       |
      ::: src/lib.rs:32:1
       |
    32 | extern crate time;
       | ------------------ the item `time` is already imported here
       |
       = note: `#[warn(unused_imports)]` on by default

    warning: the item `std` is imported redundantly
     --> src/jit.rs:8:5
      |
    8 | use std;
      |     ^^^ the item `std` is already imported by prelude
