### PR TITLE
Add no_std compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        toolchain: [stable, beta, nightly]
+        features: [--all-features]
         include:
-          - toolchain: stable
-          - toolchain: beta
           - toolchain: nightly
-
+            features: --no-default-features
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -33,12 +33,12 @@ jobs:
           override: true
           components: clippy
 
-      - name: Build with ${{ matrix.toolchain }}
+      - name: Build with ${{ matrix.toolchain }}, ${{ matrix.features }}
         run: |
           cargo +${{ matrix.toolchain }} build \
-              --release --all-features --all-targets
+              --release ${{ matrix.features }} --all-targets
 
-      - name: Test with ${{ matrix.toolchain }}
+      - name: Test with ${{ matrix.toolchain }}, ${{ matrix.features }}
         run: |
           if [[ "${{ matrix.toolchain }}" == 'nightly' ]]; then
               export RUSTDOCFLAGS='-Zsanitizer=address'
@@ -47,7 +47,7 @@ jobs:
           fi
           cargo +${{ matrix.toolchain }} test \
               --target=x86_64-unknown-linux-gnu \
-              --all-features
+              ${{ matrix.features }}
 
       - name: Lint with ${{ matrix.toolchain }}
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ json = "0.11"
 hex = "0.4.3"
 
 [features]
-default = []
+default = ["std"]
+std = []
 cranelift = [
     "dep:cranelift-codegen",
     "dep:cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,15 @@ include = [
 
 [dependencies]
 
-combine = "4.6"
-libc = "0.2"
-time = "0.2"
-byteorder = "1.2"
+# Default features (std) are disabled so that the dependencies don't pull in the
+# standard library when the crate is compiled for no_std
+byteorder = { version = "1.2", default-features = false }
+log = {version = "0.4.21", default-features = false }
+combine = { version = "4.6", default-features = false }
+
+# Optional Dependencies when using the standard library
+libc = { version = "0.2", optional = true }
+time = { version = "0.2", optional = true }
 
 # Optional Dependencies for the CraneLift JIT
 cranelift-codegen = { version = "0.99", optional = true }
@@ -44,7 +49,8 @@ hex = "0.4.3"
 
 [features]
 default = ["std"]
-std = []
+cargo-clippy = []
+std = ["dep:time", "dep:libc", "combine/std"]
 cranelift = [
     "dep:cranelift-codegen",
     "dep:cranelift-frontend",
@@ -52,3 +58,23 @@ cranelift = [
     "dep:cranelift-native",
     "dep:cranelift-module",
 ]
+
+# Examples that depend on the standard library should be disabled when
+# testing the `no_std` configuration.
+[[example]]
+name = "disassemble"
+required-features = ["std"]
+
+[[example]]
+name = "load_elf"
+required-features = ["std"]
+
+[[example]]
+name = "uptime"
+required-features = ["std"]
+
+[[example]]
+name = "to_json"
+
+[[example]]
+name = "rbpf_plugin"

--- a/README.md
+++ b/README.md
@@ -447,9 +447,12 @@ fn main() {
     let mut vm = rbpf::EbpfVmFixedMbuff::new(Some(prog), 0x40, 0x50).unwrap();
 
     // We register a helper function, that can be called by the program, into
-    // the VM.
-    vm.register_helper(helpers::BPF_TRACE_PRINTK_IDX,
-                       helpers::bpf_trace_printf).unwrap();
+    // the VM. The `bpf_trace_printf` is only available when we have access to
+    // the standard library.
+    #[cfg(feature = "std")] {
+        vm.register_helper(helpers::BPF_TRACE_PRINTK_IDX,
+                           helpers::bpf_trace_printf).unwrap();
+    }
 
     // This kind of VM takes a reference to the packet data, but does not need
     // any reference to the metadata buffer: a fixed buffer is handled
@@ -479,7 +482,9 @@ let prog = assemble("add64 r1, 0x605
                      neg64 r2
                      exit").unwrap();
 
-println!("{:?}", prog);
+#[cfg(feature = "std")] {
+    println!("{:?}", prog);
+}
 ```
 
 The above snippet will produce:

--- a/README.md
+++ b/README.md
@@ -306,10 +306,10 @@ fn main() {
     // directly reads from packet data)
     let mut vm = rbpf::EbpfVmRaw::new(Some(prog)).unwrap();
 
-    #[cfg(windows)] {
+    #[cfg(any(windows, not(feature = "std")))] {
         assert_eq!(vm.execute_program(mem).unwrap(), 0x11);
     }
-    #[cfg(not(windows))] {
+    #[cfg(all(not(windows), feature = "std"))] {
         // This time we JIT-compile the program.
         vm.jit_compile().unwrap();
 
@@ -352,10 +352,10 @@ fn main() {
     // This eBPF VM is for program that use a metadata buffer.
     let mut vm = rbpf::EbpfVmMbuff::new(Some(prog)).unwrap();
 
-    #[cfg(windows)] {
+    #[cfg(any(windows, not(feature = "std")))] {
         assert_eq!(vm.execute_program(mem, mbuff).unwrap(), 0x2211);
     }
-    #[cfg(not(windows))] {
+    #[cfg(all(not(windows), feature = "std"))] {
         // Here again we JIT-compile the program.
         vm.jit_compile().unwrap();
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Rust (user-space) virtual machine for eBPF
 * [API](#api)
 * [Example uses](#example-uses)
 * [Building eBPF programs](#building-ebpf-programs)
+* [Build Features](#build-features)
 * [Feedback welcome!](#feedback-welcome)
 * [Questions / Answers](#questions--answers)
 * [Caveats](#caveats)
@@ -554,6 +555,30 @@ program.add(Source::Imm, Arch::X64).set_dst(1).set_imm(0x605).push()
 
 Again, please refer to [the source and related tests](src/insn_builder.rs) to
 get more information and examples on how to use it.
+
+## Build features
+
+### `no_std`
+
+The `rbpf` crate has a Cargo feature named "std" that is enabled by default. To
+use `rbpf` in `no_std` environments this feature needs to be disabled. To do
+this, you need to modify your dependency on `rbpf` in Cargo.toml to disable the
+enabled-by-default features.
+
+```toml
+[dependencies]
+rbpf = { version = "1.0", default-features = false }
+```
+
+Note that when using this crate in `no_std` environments, the `jit` module
+isn't available. This is because it depends on functions provided by `libc`
+(`libc::posix_memalign()`, `libc::mprotect()`) which aren't available on
+`no_std`.
+
+The `assembler` module is available, albeit with reduced debugging features. It
+depends on the `combine` crate providing parser combinators. Under `no_std`
+this crate only provides simple parsers which generate less descriptive error
+messages.
 
 ## Feedback welcome!
 

--- a/examples/rbpf_plugin.rs
+++ b/examples/rbpf_plugin.rs
@@ -15,6 +15,7 @@ fn _unwind(a: u64, _b: u64, _c: u64, _d: u64, _e: u64) -> u64
 // It reads the program from stdin.
 fn main() {
     let mut args: Vec<String> = std::env::args().collect();
+    #[allow(unused_mut)] // In no_std the jit variable isn't mutated.
     let mut jit : bool = false;
     let mut cranelift : bool = false;
     let mut program_text = String::new();

--- a/examples/rbpf_plugin.rs
+++ b/examples/rbpf_plugin.rs
@@ -38,11 +38,11 @@ fn main() {
                 return;
             },
             "--jit" => {
-                #[cfg(windows)] {
-                    println!("JIT not supported on Windows");
+                #[cfg(any(windows, not(feature = "std")))] {
+                    println!("JIT not supported");
                     return;
                 }
-                #[cfg(not(windows))] {
+                #[cfg(all(not(windows), feature = "std"))] {
                     jit = true;
                 }
             },
@@ -93,11 +93,11 @@ fn main() {
 
     let result : u64;
     if jit {
-        #[cfg(windows)] {
-            println!("JIT not supported on Windows");
+        #[cfg(any(windows, not(feature = "std")))] {
+            println!("JIT not supported");
             return;
         }
-        #[cfg(not(windows))] {
+        #[cfg(all(not(windows), feature = "std"))] {
             unsafe {
                 vm.jit_compile().unwrap();
                 result = vm.execute_program_jit(&mut memory).unwrap();

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -52,14 +52,14 @@ fn main() {
 
     let time;
 
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     {
         vm.jit_compile().unwrap();
 
         time = unsafe { vm.execute_program_jit().unwrap() };
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, not(feature = "std")))]
     {
         time = vm.execute_program().unwrap();
     }

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -6,10 +6,10 @@
 use asm_parser::{Instruction, Operand, parse};
 use ebpf;
 use ebpf::Insn;
-use std::collections::HashMap;
 use self::InstructionType::{AluBinary, AluUnary, LoadAbs, LoadInd, LoadImm, LoadReg, StoreImm,
                             StoreReg, JumpUnconditional, JumpConditional, Call, Endian, NoOperand};
 use asm_parser::Operand::{Integer, Memory, Register, Nil};
+use crate::lib::*;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum InstructionType {

--- a/src/cranelift.rs
+++ b/src/cranelift.rs
@@ -1,12 +1,5 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    convert::TryInto,
-    io::ErrorKind,
-    mem::ManuallyDrop,
-};
-
 use cranelift_codegen::{
     entity::EntityRef,
     ir::{
@@ -26,6 +19,7 @@ use crate::ebpf::{
     self, Insn, BPF_ALU_OP_MASK, BPF_JEQ, BPF_JGE, BPF_JGT, BPF_JLE, BPF_JLT, BPF_JMP32, BPF_JNE,
     BPF_JSET, BPF_JSGE, BPF_JSGT, BPF_JSLE, BPF_JSLT, BPF_X, STACK_SIZE, BPF_IND,
 };
+use crate::lib::*;
 
 use super::Error;
 
@@ -1197,7 +1191,7 @@ impl CraneliftProgram {
     /// module, since it's not guaranteed to be valid after the module is dropped.
     pub(crate) fn get_main_function(&self) -> JittedFunction {
         let function_ptr = self.module.get_finalized_function(self.main_id);
-        unsafe { std::mem::transmute(function_ptr) }
+        unsafe { mem::transmute(function_ptr) }
     }
 
     /// Execute this module by calling the main function

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -4,7 +4,12 @@
 //! Functions in this module are used to handle eBPF programs with a higher level representation,
 //! for example to disassemble the code into a human-readable format.
 
+use log::warn;
+#[cfg(not(feature = "std"))]
+use log::info;
+
 use ebpf;
+use crate::lib::*;
 
 #[inline]
 fn alu_imm_str(name: &str, insn: &ebpf::Insn) -> String {
@@ -20,7 +25,7 @@ fn alu_reg_str(name: &str, insn: &ebpf::Insn) -> String {
 fn byteswap_str(name: &str, insn: &ebpf::Insn) -> String {
     match insn.imm {
         16 | 32 | 64 => {},
-        _ => println!("[Disassembler] Warning: Invalid offset value for {name} insn")
+        _ => warn!("[Disassembler] Warning: Invalid offset value for {name} insn")
     }
     format!("{name}{} r{}", insn.imm, insn.dst)
 }
@@ -384,7 +389,14 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
 /// exit
 /// ```
 pub fn disassemble(prog: &[u8]) {
-    for insn in to_insn_vec(prog) {
-        println!("{}", insn.desc);
+    #[cfg(feature = "std")] {
+        for insn in to_insn_vec(prog) {
+            println!("{}", insn.desc);
+        }
+    }
+    #[cfg(not(feature = "std"))] {
+        for insn in to_insn_vec(prog) {
+            info!("{}", insn.desc);
+        }
     }
 }

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -15,6 +15,7 @@
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
 use byteorder::{ByteOrder, LittleEndian};
+use crate::lib::*;
 
 /// Maximum number of instructions in an eBPF program.
 pub const PROG_MAX_INSNS: usize = 1000000;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,9 +16,10 @@
 //! value. Hence some helpers have unused arguments, or return a 0 value in all cases, in order to
 //! respect this convention.
 
+#[cfg(feature = "std")]
 extern crate libc;
 
-use std::u64;
+use crate::lib::*;
 
 // Helpers associated to kernel helpers
 // See also linux/include/uapi/linux/bpf.h in Linux kernel sources.
@@ -47,6 +48,7 @@ pub const BPF_KTIME_GETNS_IDX: u32 = 5;
 #[allow(dead_code)]
 #[allow(unused_variables)]
 #[allow(deprecated)]
+#[cfg(feature = "std")]
 pub fn bpf_time_getns (unused1: u64, unused2: u64, unused3: u64, unused4: u64, unused5: u64) -> u64 {
     time::precise_time_ns()
 }
@@ -94,6 +96,7 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 /// program is run.
 #[allow(dead_code)]
 #[allow(unused_variables)]
+#[cfg(feature = "std")]
 pub fn bpf_trace_printf (unused1: u64, unused2: u64, arg3: u64, arg4: u64, arg5: u64) -> u64 {
     println!("bpf_trace_printf: {arg3:#x}, {arg4:#x}, {arg5:#x}");
     let size_arg = | x | {
@@ -191,6 +194,7 @@ pub fn memfrob (ptr: u64, len: u64, unused3: u64, unused4: u64, unused5: u64) ->
 /// ```
 #[allow(dead_code)]
 #[allow(unused_variables)]
+#[cfg(feature = "std")] // sqrt is only available when using `std`
 pub fn sqrti (arg1: u64, unused2: u64, unused3: u64, unused4: u64, unused5: u64) -> u64 {
     (arg1 as f64).sqrt() as u64
 }
@@ -258,6 +262,7 @@ pub fn strcmp (arg1: u64, arg2: u64, arg3: u64, unused4: u64, unused5: u64) -> u
 /// ```
 #[allow(dead_code)]
 #[allow(unused_variables)]
+#[cfg(feature = "std")]
 pub fn rand (min: u64, max: u64, unused3: u64, unused4: u64, unused5: u64) -> u64 {
     let mut n = unsafe {
         (libc::rand() as u64).wrapping_shl(32) + libc::rand() as u64

--- a/src/insn_builder.rs
+++ b/src/insn_builder.rs
@@ -4,6 +4,7 @@
 //! Module provides API to create eBPF programs by Rust programming language
 
 use ebpf::*;
+use crate::lib::*;
 
 /// Represents single eBPF instruction
 pub trait Instruction: Sized {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -5,10 +5,8 @@
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 //      (Translation to Rust, MetaBuff/multiple classes addition, hashmaps for helpers)
 
-use std::collections::HashMap;
-use std::io::{Error, ErrorKind};
-
 use ebpf;
+use crate::lib::*;
 
 fn check_mem(addr: u64, len: usize, access_type: &str, insn_ptr: usize,
              mbuff: &[u8], mem: &[u8], stack: &[u8]) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub mod ebpf;
 pub mod helpers;
 pub mod insn_builder;
 mod interpreter;
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 mod jit;
 mod verifier;
 
@@ -118,7 +118,7 @@ struct MetaBuff {
 pub struct EbpfVmMbuff<'a> {
     prog: Option<&'a [u8]>,
     verifier: Verifier,
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     jit: Option<jit::JitMemory<'a>>,
     #[cfg(feature = "cranelift")]
     cranelift_prog: Option<cranelift::CraneliftProgram>,
@@ -149,7 +149,7 @@ impl<'a> EbpfVmMbuff<'a> {
         Ok(EbpfVmMbuff {
             prog,
             verifier: verifier::check,
-            #[cfg(not(windows))]
+            #[cfg(all(not(windows), feature = "std"))]
             jit: None,
             #[cfg(feature = "cranelift")]
             cranelift_prog: None,
@@ -319,7 +319,7 @@ impl<'a> EbpfVmMbuff<'a> {
     ///
     /// vm.jit_compile();
     /// ```
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     pub fn jit_compile(&mut self) -> Result<(), Error> {
         let prog = match self.prog {
             Some(prog) => prog,
@@ -374,17 +374,17 @@ impl<'a> EbpfVmMbuff<'a> {
     /// // Instantiate a VM.
     /// let mut vm = rbpf::EbpfVmMbuff::new(Some(prog)).unwrap();
     ///
-    /// # #[cfg(not(windows))]
+    /// # #[cfg(all(not(windows), feature = "std"))]
     /// vm.jit_compile();
     ///
     /// // Provide both a reference to the packet data, and to the metadata buffer.
-    /// # #[cfg(not(windows))]
+    /// # #[cfg(all(not(windows), feature = "std"))]
     /// unsafe {
     ///     let res = vm.execute_program_jit(mem, &mut mbuff).unwrap();
     ///     assert_eq!(res, 0x2211);
     /// }
     /// ```
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     pub unsafe fn execute_program_jit(
         &self,
         mem: &mut [u8],
@@ -835,7 +835,7 @@ impl<'a> EbpfVmFixedMbuff<'a> {
     ///
     /// vm.jit_compile();
     /// ```
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     pub fn jit_compile(&mut self) -> Result<(), Error> {
         let prog = match self.parent.prog {
             Some(prog) => prog,
@@ -884,11 +884,11 @@ impl<'a> EbpfVmFixedMbuff<'a> {
     /// // Instantiate a VM. Note that we provide the start and end offsets for mem pointers.
     /// let mut vm = rbpf::EbpfVmFixedMbuff::new(Some(prog), 0x40, 0x50).unwrap();
     ///
-    /// # #[cfg(not(windows))]
+    /// # #[cfg(all(not(windows), feature = "std"))]
     /// vm.jit_compile();
     ///
     /// // Provide only a reference to the packet data. We do not manage the metadata buffer.
-    /// # #[cfg(not(windows))]
+    /// # #[cfg(all(not(windows), feature = "std"))]
     /// unsafe {
     ///     let res = vm.execute_program_jit(mem).unwrap();
     ///     assert_eq!(res, 0xdd);
@@ -896,7 +896,7 @@ impl<'a> EbpfVmFixedMbuff<'a> {
     /// ```
     // This struct redefines the `execute_program_jit()` function, in order to pass the offsets
     // associated with the fixed mbuff.
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     pub unsafe fn execute_program_jit(&mut self, mem: &'a mut [u8]) -> Result<u64, Error> {
         // If packet data is empty, do not send the address of an empty slice; send a null pointer
         //  as first argument instead, as this is uBPF's behavior (empty packet should not happen
@@ -1240,7 +1240,7 @@ impl<'a> EbpfVmRaw<'a> {
     ///
     /// vm.jit_compile();
     /// ```
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     pub fn jit_compile(&mut self) -> Result<(), Error> {
         let prog = match self.parent.prog {
             Some(prog) => prog,
@@ -1286,16 +1286,16 @@ impl<'a> EbpfVmRaw<'a> {
     ///
     /// let mut vm = rbpf::EbpfVmRaw::new(Some(prog)).unwrap();
     ///
-    /// # #[cfg(not(windows))]
+    /// # #[cfg(all(not(windows), feature = "std"))]
     /// vm.jit_compile();
     ///
-    /// # #[cfg(not(windows))]
+    /// # #[cfg(all(not(windows), feature = "std"))]
     /// unsafe {
     ///     let res = vm.execute_program_jit(mem).unwrap();
     ///     assert_eq!(res, 0x22cc);
     /// }
     /// ```
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     pub unsafe fn execute_program_jit(&self, mem: &'a mut [u8]) -> Result<u64, Error> {
         let mut mbuff = vec![];
         self.parent.execute_program_jit(mem, &mut mbuff)
@@ -1555,7 +1555,7 @@ impl<'a> EbpfVmNoData<'a> {
     ///
     /// vm.jit_compile();
     /// ```
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     pub fn jit_compile(&mut self) -> Result<(), Error> {
         self.parent.jit_compile()
     }
@@ -1604,16 +1604,16 @@ impl<'a> EbpfVmNoData<'a> {
     ///
     /// let mut vm = rbpf::EbpfVmNoData::new(Some(prog)).unwrap();
     ///
-    /// # #[cfg(not(windows))]
+    /// # #[cfg(all(not(windows), feature = "std"))]
     /// vm.jit_compile();
     ///
-    /// # #[cfg(not(windows))]
+    /// # #[cfg(all(not(windows), feature = "std"))]
     /// unsafe {
     ///     let res = vm.execute_program_jit().unwrap();
     ///     assert_eq!(res, 0x1122);
     /// }
     /// ```
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "std"))]
     pub unsafe fn execute_program_jit(&self) -> Result<u64, Error> {
         self.parent.execute_program_jit(&mut [])
     }

--- a/src/no_std_error.rs
+++ b/src/no_std_error.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+//! This module provides a simple implementation of the Error struct that is
+//! used as a drop-in replacement for `std::io::Error` when using `rbpf` in `no_std`.
+
+use crate::lib::String;
+
+/// Implementation of Error for no_std applications.
+/// Ensures that the existing code can use it with the same interface
+/// as the Error from std::io::Error.
+#[derive(Debug)]
+pub struct Error {
+    #[allow(dead_code)]
+    kind: ErrorKind,
+    #[allow(dead_code)]
+    error: String,
+}
+
+impl Error {
+    /// New function exposing the same signature as `std::io::Error::new`.
+    #[allow(dead_code)]
+    pub fn new<S: Into<String>>(kind: ErrorKind, error: S) -> Error {
+        Error {
+            kind,
+            error: error.into(),
+        }
+    }
+}
+
+/// The current version of `rbpf` only uses the [`Other`](ErrorKind::Other) variant
+/// from the [std::io::ErrorKind] enum. If a dependency on other variants were
+/// introduced in the future, this enum needs to be updated accordingly to maintain
+/// compatibility with the real `ErrorKind`. The reason all available variants
+/// aren't included in the first place is that [std::io::ErrorKind] exposes
+/// 40 variants, and not all of them are meaningful under `no_std`.
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// The no_std code only uses this variant.
+    #[allow(dead_code)]
+    Other,
+}
+

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -20,7 +20,7 @@
 
 
 use ebpf;
-use std::io::{Error, ErrorKind};
+use crate::lib::*;
 
 fn reject<S: AsRef<str>>(msg: S) -> Result<(), Error> {
     let full_msg = format!("[Verifier] Error: {}", msg.as_ref());

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -170,7 +170,7 @@ fn test_vm_block_port() {
     assert_eq!(res, 0xffffffff);
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_jit_block_port() {
     // To load the bytecode from an object file instead of using the hardcoded instructions,
@@ -309,7 +309,7 @@ fn test_vm_mbuff_with_rust_api() {
 }
 
 // Program and memory come from uBPF test ldxh.
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_jit_mbuff() {
     let prog = &[
@@ -338,7 +338,7 @@ fn test_jit_mbuff() {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_vm_jit_ldabsb() {
     let prog = &[
@@ -358,7 +358,7 @@ fn test_vm_jit_ldabsb() {
     };
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_vm_jit_ldabsh() {
     let prog = &[
@@ -378,7 +378,7 @@ fn test_vm_jit_ldabsh() {
     };
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_vm_jit_ldabsw() {
     let prog = &[
@@ -398,7 +398,7 @@ fn test_vm_jit_ldabsw() {
     };
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_vm_jit_ldabsdw() {
     let prog = &[
@@ -448,7 +448,7 @@ fn test_vm_err_ldabsb_nomem() {
     // Memory check not implemented for JIT yet.
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_vm_jit_ldindb() {
     let prog = &[
@@ -469,7 +469,7 @@ fn test_vm_jit_ldindb() {
     };
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_vm_jit_ldindh() {
     let prog = &[
@@ -490,7 +490,7 @@ fn test_vm_jit_ldindh() {
     };
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_vm_jit_ldindw() {
     let prog = &[
@@ -511,7 +511,7 @@ fn test_vm_jit_ldindw() {
     };
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "std"))]
 #[test]
 fn test_vm_jit_ldinddw() {
     let prog = &[

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -19,8 +19,9 @@
 
 extern crate rbpf;
 
-use std::io::{Error, ErrorKind};
+use rbpf::lib::{Error, ErrorKind};
 use rbpf::assembler::assemble;
+#[cfg(feature = "std")]
 use rbpf::helpers;
 
 // The following two examples have been compiled from C with the following command:
@@ -90,6 +91,7 @@ use rbpf::helpers;
 // instead.
 
 #[test]
+#[cfg(feature = "std")]
 fn test_vm_block_port() {
     // To load the bytecode from an object file instead of using the hardcoded instructions,
     // use the additional crates commented at the beginning of this file (and also add them to your
@@ -170,8 +172,8 @@ fn test_vm_block_port() {
     assert_eq!(res, 0xffffffff);
 }
 
-#[cfg(all(not(windows), feature = "std"))]
 #[test]
+#[cfg(all(not(windows), feature = "std"))]
 fn test_jit_block_port() {
     // To load the bytecode from an object file instead of using the hardcoded instructions,
     // use the additional crates commented at the beginning of this file (and also add them to your
@@ -309,8 +311,8 @@ fn test_vm_mbuff_with_rust_api() {
 }
 
 // Program and memory come from uBPF test ldxh.
-#[cfg(all(not(windows), feature = "std"))]
 #[test]
+#[cfg(all(not(windows), feature = "std"))]
 fn test_jit_mbuff() {
     let prog = &[
         // Load mem from mbuff into R1

--- a/tests/ubpf_jit_x86_64.rs
+++ b/tests/ubpf_jit_x86_64.rs
@@ -17,7 +17,7 @@
 // These are unit tests for the eBPF JIT compiler.
 
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
-#![cfg(not(windows))]
+#![cfg(all(not(windows), feature = "std"))]
 
 extern crate rbpf;
 mod common;


### PR DESCRIPTION
### What was added?

Added support for rbpf to run on `no_std` environments. 

### Why is it needed?

Using rbpf on targets without `std` support increases compatibility of the crate. 
I've been using a modified version of rbpf to run eBPF programs on microcontrollers (see [here(https://github.com/SzymonKubica/mibpf))

### Testing

Currently the code builds successfuly with both configuration options enabled, i.e. all build configurations succeed:
```
cargo build
cargo build --features cranelift
cargo build --no-default-features
cargo build --features cranelift --no-default-features
```

All tests (except for the ones using the `print` - only available in std) pass in both configuration options.

### TODO items for the  PR

- [x] test `no_std` on an example embedded device

### Notes

The structure of `std` / `no_std` feature-gating is inspired by `serde`, inside of `lib.rs` a public module: `lib` is defined and it 
contains reexports of all required items from std/alloc/core. It is then used throughout the codebase by importing all items 
declared inside of it: 
```
use crate::lib::*;
```
This behaves similarly as if we were using the standard library as we don't have to import things like `String` or `Vec` manually. 
