### PR TITLE
Version bump (0.3.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # Project metadata
 name = "rbpf"
 version = "0.2.0"
-authors = ["Quentin <quentin@isovalent.com>"]
+authors = ["Quentin Monnet <qmo@qmon.net>"]
 
 # Additional metadata for packaging
 description = "Virtual machine and JIT compiler for eBPF programs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 # Project metadata
 name = "rbpf"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Quentin Monnet <qmo@qmon.net>"]
 
 # Additional metadata for packaging

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ file:
 
 ```toml
 [dependencies]
-rbpf = "0.2.0"
+rbpf = "0.3.0"
 ```
 
 You can also use the development version from this GitHub repository. This
@@ -388,7 +388,7 @@ to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-rbpf = "0.2.0"
+rbpf = "0.3.0"
 elf = "0.0.10"
 ```
 
@@ -577,7 +577,7 @@ enabled-by-default features.
 
 ```toml
 [dependencies]
-rbpf = { version = "1.0", default-features = false }
+rbpf = { version = "0.3.0", default-features = false }
 ```
 
 Note that when using this crate in `no_std` environments, the `jit` module


### PR DESCRIPTION
Commits:

- **Cargo.toml: Update author email**
- **Cargo.toml,README.md: Bump version to 0.3.0**

We got a bunch of new features since version 0.2.0, in particular:

- A new JIT-compiling infrastructure via Cranelift (opt-in feature)
- The ability to compile and use most of rbpf's features without the standard library
- An API update to allow eBPF helpers to use designated memory area in our simple verifier, so that users can hook their map implementation
- Several bug fixes

Let's update the crate so that users can benefit from these.
