### PR TITLE
fix(doc): Add compilation instructions for aya ebpf example

### DIFF
--- a/examples/allowed-memory/README.md
+++ b/examples/allowed-memory/README.md
@@ -1,0 +1,10 @@
+This directory contains an example eBPF program for testing memory access with
+helper functions in rbpf.
+
+To recompile the program, make sure to install all of
+[Aya's prerequisites](https://aya-rs.dev/book/start/development/),
+then run from this directory:
+
+```bash
+cargo build --release
+```


### PR DESCRIPTION
I realized that I forgot to add the README with the compilation instructions.