### PR TITLE
Clippy update

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,9 +49,9 @@ jobs:
               --target=x86_64-unknown-linux-gnu \
               ${{ matrix.features }}
 
-      - name: Lint with ${{ matrix.toolchain }}
+      - name: Lint with ${{ matrix.toolchain }}, ${{ matrix.features }}
         run: |
-          cargo +${{ matrix.toolchain }} clippy
+          cargo +${{ matrix.toolchain }} clippy ${{ matrix.features }}
 
   conformance_and_coverage:
     name: Check eBPF conformance and code coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ hex = "0.4.3"
 
 [features]
 default = ["std"]
-cargo-clippy = []
 std = ["dep:time", "dep:libc", "combine/std"]
 cranelift = [
     "dep:cranelift-codegen",

--- a/examples/allowed_memory.rs
+++ b/examples/allowed_memory.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 // Copyright 2024 Akenes SA <wouter.dullaert@exoscale.ch>
 
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 extern crate elf;
 use std::{iter::FromIterator, ptr::addr_of};

--- a/examples/allowed_memory.rs
+++ b/examples/allowed_memory.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 // Copyright 2024 Akenes SA <wouter.dullaert@exoscale.ch>
 
-#![allow(clippy::unreadable_literal)]
-
 extern crate elf;
 use std::{iter::FromIterator, ptr::addr_of};
 

--- a/examples/load_elf.rs
+++ b/examples/load_elf.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 
-#![allow(clippy::unreadable_literal)]
-
 extern crate elf;
 use std::path::PathBuf;
 

--- a/examples/load_elf.rs
+++ b/examples/load_elf.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 extern crate elf;
 use std::path::PathBuf;

--- a/examples/rbpf_plugin.rs
+++ b/examples/rbpf_plugin.rs
@@ -15,7 +15,7 @@ fn _unwind(a: u64, _b: u64, _c: u64, _d: u64, _e: u64) -> u64
 // It reads the program from stdin.
 fn main() {
     let mut args: Vec<String> = std::env::args().collect();
-    #[allow(unused_mut)] // In no_std the jit variable isn't mutated.
+    #[cfg_attr(not(feature = "std"), allow(unused_mut))] // In no_std the jit variable isn't mutated.
     let mut jit : bool = false;
     let mut cranelift : bool = false;
     let mut program_text = String::new();

--- a/src/cranelift.rs
+++ b/src/cranelift.rs
@@ -80,10 +80,10 @@ impl CraneliftCompiler {
             jit_builder.symbol(name, (*v) as usize as *const u8);
         }
 
-        let mut module = JITModule::new(jit_builder);
+        let module = JITModule::new(jit_builder);
 
         let registers = (0..11)
-            .map(|i| Variable::new(i))
+            .map(Variable::new)
             .collect::<Vec<_>>()
             .try_into()
             .unwrap();

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -173,8 +173,6 @@ pub const LD_IND_W   : u8 = BPF_LD    | BPF_IND | BPF_W;
 /// BPF opcode: `ldinddw src, dst, imm`.
 pub const LD_IND_DW  : u8 = BPF_LD    | BPF_IND | BPF_DW;
 
-#[allow(unknown_lints)]
-#[allow(clippy::eq_op)]
 /// BPF opcode: `lddw dst, imm` /// `dst = imm`.
 pub const LD_DW_IMM  : u8 = BPF_LD    | BPF_IMM | BPF_DW;
 /// BPF opcode: `ldxb dst, [src + off]` /// `dst = (src + off) as u8`.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,6 +16,7 @@
 //! value. Hence some helpers have unused arguments, or return a 0 value in all cases, in order to
 //! respect this convention.
 
+#[cfg(feature = "std")]
 use crate::lib::*;
 
 // Helpers associated to kernel helpers
@@ -150,7 +151,7 @@ pub fn gather_bytes (arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> u
 pub fn memfrob (ptr: u64, len: u64, unused3: u64, unused4: u64, unused5: u64) -> u64 {
     for i in 0..len {
         unsafe {
-            let mut p = (ptr + i) as *mut u8;
+            let p = (ptr + i) as *mut u8;
             *p ^= 0b101010;
         }
     }

--- a/src/insn_builder.rs
+++ b/src/insn_builder.rs
@@ -73,7 +73,7 @@ pub trait IntoBytes {
 }
 
 /// General implementation of `IntoBytes` for `Instruction`
-impl<'i, I: Instruction> IntoBytes for &'i I {
+impl<I: Instruction> IntoBytes for &I {
     type Bytes = Vec<u8>;
 
     /// transform immutable reference of `Instruction` into `Vec<u8>` with size of 8
@@ -344,7 +344,7 @@ impl<'i> Move<'i> {
     }
 }
 
-impl<'i> Instruction for Move<'i> {
+impl Instruction for Move<'_> {
     fn opt_code_byte(&self) -> u8 {
         let op_bits = self.op_bits as u8;
         let src_bit = self.src_bit as u8;
@@ -412,7 +412,7 @@ impl<'i> SwapBytes<'i> {
     }
 }
 
-impl<'i> Instruction for SwapBytes<'i> {
+impl Instruction for SwapBytes<'_> {
     fn opt_code_byte(&self) -> u8 {
         self.endian as u8
     }
@@ -453,7 +453,7 @@ impl<'i> Load<'i> {
     }
 }
 
-impl<'i> Instruction for Load<'i> {
+impl Instruction for Load<'_> {
     fn opt_code_byte(&self) -> u8 {
         let size = self.mem_size as u8;
         let addressing = self.addressing as u8;
@@ -486,7 +486,7 @@ impl<'i> Store<'i> {
     }
 }
 
-impl<'i> Instruction for Store<'i> {
+impl Instruction for Store<'_> {
     fn opt_code_byte(&self) -> u8 {
         let size = self.mem_size as u8;
         BPF_MEM | BPF_ST | size | self.source
@@ -539,7 +539,7 @@ impl<'i> Jump<'i> {
     }
 }
 
-impl<'i> Instruction for Jump<'i> {
+impl Instruction for Jump<'_> {
     fn opt_code_byte(&self) -> u8 {
         let cmp: u8 = self.cond as u8;
         let src_bit = self.src_bit as u8;
@@ -599,7 +599,7 @@ impl<'i> FunctionCall<'i> {
     }
 }
 
-impl<'i> Instruction for FunctionCall<'i> {
+impl Instruction for FunctionCall<'_> {
     fn opt_code_byte(&self) -> u8 {
         BPF_CALL | BPF_JMP
     }
@@ -628,7 +628,7 @@ impl<'i> Exit<'i> {
     }
 }
 
-impl<'i> Instruction for Exit<'i> {
+impl Instruction for Exit<'_> {
     fn opt_code_byte(&self) -> u8 {
         BPF_EXIT | BPF_JMP
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -43,8 +43,6 @@ fn check_mem(
     )))
 }
 
-#[allow(unknown_lints)]
-#[allow(cyclomatic_complexity)]
 pub fn execute_program(
     prog_: Option<&[u8]>,
     mem: &[u8],
@@ -147,25 +145,21 @@ pub fn execute_program(
 
             // BPF_LDX class
             ebpf::LD_B_REG   => reg[_dst] = unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_src] as *const u8).wrapping_offset(insn.off as isize);
                 check_mem_load(x as u64, 1, insn_ptr)?;
                 x.read_unaligned() as u64
             },
             ebpf::LD_H_REG   => reg[_dst] = unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_src] as *const u8).wrapping_offset(insn.off as isize) as *const u16;
                 check_mem_load(x as u64, 2, insn_ptr)?;
                 x.read_unaligned() as u64
             },
             ebpf::LD_W_REG   => reg[_dst] = unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_src] as *const u8).wrapping_offset(insn.off as isize) as *const u32;
                 check_mem_load(x as u64, 4, insn_ptr)?;
                 x.read_unaligned() as u64
             },
             ebpf::LD_DW_REG  => reg[_dst] = unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_src] as *const u8).wrapping_offset(insn.off as isize) as *const u64;
                 check_mem_load(x as u64, 8, insn_ptr)?;
                 x.read_unaligned()
@@ -178,19 +172,16 @@ pub fn execute_program(
                 x.write_unaligned(insn.imm as u8);
             },
             ebpf::ST_H_IMM   => unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_dst] as *const u8).wrapping_offset(insn.off as isize) as *mut u16;
                 check_mem_store(x as u64, 2, insn_ptr)?;
                 x.write_unaligned(insn.imm as u16);
             },
             ebpf::ST_W_IMM   => unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_dst] as *const u8).wrapping_offset(insn.off as isize) as *mut u32;
                 check_mem_store(x as u64, 4, insn_ptr)?;
                 x.write_unaligned(insn.imm as u32);
             },
             ebpf::ST_DW_IMM  => unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_dst] as *const u8).wrapping_offset(insn.off as isize) as *mut u64;
                 check_mem_store(x as u64, 8, insn_ptr)?;
                 x.write_unaligned(insn.imm as u64);
@@ -203,19 +194,16 @@ pub fn execute_program(
                 x.write_unaligned(reg[_src] as u8);
             },
             ebpf::ST_H_REG   => unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_dst] as *const u8).wrapping_offset(insn.off as isize) as *mut u16;
                 check_mem_store(x as u64, 2, insn_ptr)?;
                 x.write_unaligned(reg[_src] as u16);
             },
             ebpf::ST_W_REG   => unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_dst] as *const u8).wrapping_offset(insn.off as isize) as *mut u32;
                 check_mem_store(x as u64, 4, insn_ptr)?;
                 x.write_unaligned(reg[_src] as u32);
             },
             ebpf::ST_DW_REG  => unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
                 let x = (reg[_dst] as *const u8).wrapping_offset(insn.off as isize) as *mut u64;
                 check_mem_store(x as u64, 8, insn_ptr)?;
                 x.write_unaligned(reg[_src]);

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -8,8 +8,17 @@
 use ebpf;
 use crate::lib::*;
 
-fn check_mem(addr: u64, len: usize, access_type: &str, insn_ptr: usize,
-             mbuff: &[u8], mem: &[u8], stack: &[u8], allowed_memory: &HashSet<u64>) -> Result<(), Error> {
+#[allow(clippy::too_many_arguments)]
+fn check_mem(
+    addr: u64,
+    len: usize,
+    access_type: &str,
+    insn_ptr: usize,
+    mbuff: &[u8],
+    mem: &[u8],
+    stack: &[u8],
+    allowed_memory: &HashSet<u64>
+) -> Result<(), Error> {
     if let Some(addr_end) = addr.checked_add(len as u64) {
       if mbuff.as_ptr() as u64 <= addr && addr_end <= mbuff.as_ptr() as u64 + mbuff.len() as u64 {
           return Ok(());
@@ -139,7 +148,7 @@ pub fn execute_program(
             // BPF_LDX class
             ebpf::LD_B_REG   => reg[_dst] = unsafe {
                 #[allow(clippy::cast_ptr_alignment)]
-                let x = (reg[_src] as *const u8).wrapping_offset(insn.off as isize) as *const u8;
+                let x = (reg[_src] as *const u8).wrapping_offset(insn.off as isize);
                 check_mem_load(x as u64, 1, insn_ptr)?;
                 x.read_unaligned() as u64
             },

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -83,7 +83,7 @@ macro_rules! emit_bytes {
         let size = mem::size_of::<$t>() as usize;
         assert!($mem.offset + size <= $mem.contents.len());
         unsafe {
-            let mut ptr = $mem.contents.as_ptr().add($mem.offset) as *mut $t;
+            let ptr = $mem.contents.as_ptr().add($mem.offset) as *mut $t;
             ptr.write_unaligned($data);
         }
         $mem.offset += size;
@@ -276,7 +276,7 @@ impl JitCompiler {
 
     // Load sign-extended immediate into register
     fn emit_load_imm(&self, mem: &mut JitMemory, dst: u8, imm: i64) {
-        if imm >= std::i32::MIN as i64 && imm <= std::i32::MAX as i64 {
+        if imm >= i32::MIN as i64 && imm <= i32::MAX as i64 {
             self.emit_alu64_imm32(mem, 0xc7, 0, dst, imm as i32);
         } else {
             // movabs $imm,dst
@@ -989,7 +989,7 @@ impl<'a> JitMemory<'a> {
     }
 }
 
-impl<'a> Index<usize> for JitMemory<'a> {
+impl Index<usize> for JitMemory<'_> {
     type Output = u8;
 
     fn index(&self, _index: usize) -> &u8 {
@@ -997,13 +997,13 @@ impl<'a> Index<usize> for JitMemory<'a> {
     }
 }
 
-impl<'a> IndexMut<usize> for JitMemory<'a> {
+impl IndexMut<usize> for JitMemory<'_> {
     fn index_mut(&mut self, _index: usize) -> &mut u8 {
         &mut self.contents[_index]
     }
 }
 
-impl<'a> Drop for JitMemory<'a> {
+impl Drop for JitMemory<'_> {
     fn drop(&mut self) {
         unsafe {
             alloc::dealloc(self.contents.as_mut_ptr(), self.layout);
@@ -1011,7 +1011,7 @@ impl<'a> Drop for JitMemory<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for JitMemory<'a> {
+impl std::fmt::Debug for JitMemory<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FormatterError> {
         fmt.write_str("JIT contents: [")?;
         fmt.write_str(" ] | ")?;

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -5,6 +5,8 @@
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 //      (Translation to Rust, MetaBuff addition)
 
+#![allow(clippy::single_match)]
+
 use std::alloc;
 use std::mem;
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,19 +10,6 @@
 )]
 // Test examples from README.md as part as doc tests.
 #![doc = include_str!("../README.md")]
-#![warn(missing_docs)]
-// There are unused mut warnings due to unsafe code.
-#![allow(unused_mut)]
-// Allows old-style clippy
-#![allow(renamed_and_removed_lints)]
-#![allow(
-    clippy::redundant_field_names,
-    clippy::single_match,
-    clippy::cast_lossless,
-    clippy::doc_markdown,
-    clippy::match_same_arms,
-    clippy::unreadable_literal
-)]
 // Configures the crate to be `no_std` when `std` feature is disabled.
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub mod lib {
     pub use self::core::mem::ManuallyDrop;
     pub use self::core::ptr;
 
-    pub use self::core::{f64, u32, u64};
+    pub use self::core::f64;
 
     #[cfg(feature = "std")]
     pub use std::println;
@@ -353,7 +353,7 @@ impl<'a> EbpfVmMbuff<'a> {
     /// let addrs = Vec::from_iter(start..start+size_of::<MapValue>() as u64);
     /// vm.register_allowed_memory(&addrs);
     /// ```
-    pub fn register_allowed_memory(&mut self, addrs: &[u64]) -> () {
+    pub fn register_allowed_memory(&mut self, addrs: &[u64]) {
         for i in addrs {
             self.allowed_memory.insert(*i);
         }
@@ -547,7 +547,7 @@ impl<'a> EbpfVmMbuff<'a> {
             ))?,
         };
 
-        let mut compiler = CraneliftCompiler::new(self.helpers.clone());
+        let compiler = CraneliftCompiler::new(self.helpers.clone());
         let program = compiler.compile_function(prog)?;
 
         self.cranelift_prog = Some(program);
@@ -899,7 +899,7 @@ impl<'a> EbpfVmFixedMbuff<'a> {
     /// let addrs = Vec::from_iter(start..start+size_of::<MapValue>() as u64);
     /// vm.register_allowed_memory(&addrs);
     /// ```
-    pub fn register_allowed_memory(&mut self, allowed: &[u64]) -> () {
+    pub fn register_allowed_memory(&mut self, allowed: &[u64]) {
         self.parent.register_allowed_memory(allowed)
     }
 
@@ -1097,7 +1097,7 @@ impl<'a> EbpfVmFixedMbuff<'a> {
             ))?,
         };
 
-        let mut compiler = CraneliftCompiler::new(self.parent.helpers.clone());
+        let compiler = CraneliftCompiler::new(self.parent.helpers.clone());
         let program = compiler.compile_function(prog)?;
 
         self.parent.cranelift_prog = Some(program);
@@ -1371,7 +1371,7 @@ impl<'a> EbpfVmRaw<'a> {
     /// let addrs = Vec::from_iter(start..start+size_of::<MapValue>() as u64);
     /// vm.register_allowed_memory(&addrs);
     /// ```
-    pub fn register_allowed_memory(&mut self, allowed: &[u64]) -> () {
+    pub fn register_allowed_memory(&mut self, allowed: &[u64]) {
         self.parent.register_allowed_memory(allowed)
     }
 
@@ -1511,7 +1511,7 @@ impl<'a> EbpfVmRaw<'a> {
             ))?,
         };
 
-        let mut compiler = CraneliftCompiler::new(self.parent.helpers.clone());
+        let compiler = CraneliftCompiler::new(self.parent.helpers.clone());
         let program = compiler.compile_function(prog)?;
 
         self.parent.cranelift_prog = Some(program);
@@ -1751,7 +1751,7 @@ impl<'a> EbpfVmNoData<'a> {
     /// let addrs = Vec::from_iter(start..start+size_of::<MapValue>() as u64);
     /// vm.register_allowed_memory(&addrs);
     /// ```
-    pub fn register_allowed_memory(&mut self, allowed: &[u64]) -> () {
+    pub fn register_allowed_memory(&mut self, allowed: &[u64]) {
         self.parent.register_allowed_memory(allowed)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,16 +15,13 @@
 #![allow(unused_mut)]
 // Allows old-style clippy
 #![allow(renamed_and_removed_lints)]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(
-        redundant_field_names,
-        single_match,
-        cast_lossless,
-        doc_markdown,
-        match_same_arms,
-        unreadable_literal
-    )
+#![allow(
+    clippy::redundant_field_names,
+    clippy::single_match,
+    clippy::cast_lossless,
+    clippy::doc_markdown,
+    clippy::match_same_arms,
+    clippy::unreadable_literal
 )]
 // Configures the crate to be `no_std` when `std` feature is disabled.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 // Copyright 2017 Rich Lane <lanerl@gmail.com>
 
-#![allow(clippy::unreadable_literal)]
-
 extern crate rbpf;
 mod common;
 

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 // Copyright 2017 Rich Lane <lanerl@gmail.com>
 
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 extern crate rbpf;
 mod common;

--- a/tests/cranelift.rs
+++ b/tests/cranelift.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#![allow(clippy::unreadable_literal)]
 #![cfg(feature = "cranelift")]
 
 extern crate rbpf;

--- a/tests/cranelift.rs
+++ b/tests/cranelift.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 #![cfg(feature = "cranelift")]
 
 extern crate rbpf;

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -273,8 +273,8 @@ fn test_vm_mbuff() {
 
     let mbuff = [0u8; 32];
     unsafe {
-        let mut data     = mbuff.as_ptr().offset(8)  as *mut u64;
-        let mut data_end = mbuff.as_ptr().offset(24) as *mut u64;
+        let data     = mbuff.as_ptr().offset(8)  as *mut u64;
+        let data_end = mbuff.as_ptr().offset(24) as *mut u64;
         data.write_unaligned(mem.as_ptr() as u64);
         data_end.write_unaligned(mem.as_ptr() as u64 + mem.len() as u64);
     }
@@ -300,8 +300,8 @@ fn test_vm_mbuff_with_rust_api() {
 
     let mbuff = [0u8; 32];
     unsafe {
-        let mut data     = mbuff.as_ptr().offset(8)  as *mut u64;
-        let mut data_end = mbuff.as_ptr().offset(24) as *mut u64;
+        let data     = mbuff.as_ptr().offset(8)  as *mut u64;
+        let data_end = mbuff.as_ptr().offset(24) as *mut u64;
         *data     = mem.as_ptr() as u64;
         *data_end = mem.as_ptr() as u64 + mem.len() as u64;
     }
@@ -327,8 +327,8 @@ fn test_jit_mbuff() {
 
     let mut mbuff = [0u8; 32];
     unsafe {
-        let mut data     = mbuff.as_ptr().offset(8)  as *mut u64;
-        let mut data_end = mbuff.as_ptr().offset(24) as *mut u64;
+        let data     = mbuff.as_ptr().offset(8)  as *mut u64;
+        let data_end = mbuff.as_ptr().offset(24) as *mut u64;
         *data     = mem.as_ptr() as u64;
         *data_end = mem.as_ptr() as u64 + mem.len() as u64;
     }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 
-// There are unused mut warnings due to unsafe code.
-#![allow(unused_mut)]
-#![allow(clippy::unreadable_literal)]
-
 // This crate would be needed to load bytecode from a BPF-compiled object file. Since the crate
 // is not used anywhere else in the library, it is deactivated: we do not want to load and compile
 // it just for the tests. If you want to use it, do not forget to add the following

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -3,7 +3,7 @@
 
 // There are unused mut warnings due to unsafe code.
 #![allow(unused_mut)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 // This crate would be needed to load bytecode from a BPF-compiled object file. Since the crate
 // is not used anywhere else in the library, it is deactivated: we do not want to load and compile

--- a/tests/ubpf_jit_x86_64.rs
+++ b/tests/ubpf_jit_x86_64.rs
@@ -16,7 +16,7 @@
 
 // These are unit tests for the eBPF JIT compiler.
 
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 #![cfg(all(not(windows), feature = "std"))]
 
 extern crate rbpf;

--- a/tests/ubpf_jit_x86_64.rs
+++ b/tests/ubpf_jit_x86_64.rs
@@ -16,7 +16,6 @@
 
 // These are unit tests for the eBPF JIT compiler.
 
-#![allow(clippy::unreadable_literal)]
 #![cfg(all(not(windows), feature = "std"))]
 
 extern crate rbpf;

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -16,7 +16,7 @@
 
 // These are unit tests for the eBPF interpreter.
 
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 extern crate rbpf;
 mod common;

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -16,8 +16,6 @@
 
 // These are unit tests for the eBPF interpreter.
 
-#![allow(clippy::unreadable_literal)]
-
 extern crate rbpf;
 mod common;
 


### PR DESCRIPTION
- src: Fix deprecated calls to 'feature = "cargo-clippy"'
- src: Fix Clippy reports
- ci: Add features to clippy pass
- src: Remove presumably unused Clippy directives
