### PR TITLE
Cargo.toml: Set Rust edition for the project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/qmonnet/rbpf"
 readme = "README.md"
 keywords = ["BPF", "eBPF", "interpreter", "JIT", "filtering"]
 license = "Apache-2.0/MIT"
+edition = "2021"
 
 # Packaging directives
 include = [

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -3,12 +3,12 @@
 
 //! This module translates eBPF assembly language to binary.
 
-use asm_parser::{Instruction, Operand, parse};
-use ebpf;
-use ebpf::Insn;
+use crate::asm_parser::{Instruction, Operand, parse};
+use crate::asm_parser::Operand::{Integer, Memory, Register, Nil};
+use crate::ebpf;
+use crate::ebpf::Insn;
 use self::InstructionType::{AluBinary, AluUnary, LoadAbs, LoadInd, LoadImm, LoadReg, StoreImm,
                             StoreReg, JumpUnconditional, JumpConditional, Call, Endian, NoOperand};
-use asm_parser::Operand::{Integer, Memory, Register, Nil};
 use crate::lib::*;
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -8,7 +8,7 @@ use log::warn;
 #[cfg(not(feature = "std"))]
 use log::info;
 
-use ebpf;
+use crate::ebpf;
 use crate::lib::*;
 
 #[inline]

--- a/src/insn_builder.rs
+++ b/src/insn_builder.rs
@@ -3,7 +3,7 @@
 
 //! Module provides API to create eBPF programs by Rust programming language
 
-use ebpf::*;
+use crate::ebpf::*;
 use crate::lib::*;
 
 /// Represents single eBPF instruction

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -5,7 +5,7 @@
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 //      (Translation to Rust, MetaBuff/multiple classes addition, hashmaps for helpers)
 
-use ebpf;
+use crate::ebpf;
 use crate::lib::*;
 
 #[allow(clippy::too_many_arguments)]

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -16,7 +16,7 @@ use std::io::{Error, ErrorKind};
 use std::ops::{Index, IndexMut};
 use std::ptr;
 
-use ebpf;
+use crate::ebpf;
 
 extern crate libc;
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -19,7 +19,7 @@
 // Contrary to the verifier of the Linux kernel, this one does not modify the bytecode at all.
 
 
-use ebpf;
+use crate::ebpf;
 use crate::lib::*;
 
 fn reject<S: AsRef<str>>(msg: S) -> Result<(), Error> {


### PR DESCRIPTION
Use a Rust edition for the project: 2021, and fix imports to ensure the crates builds correctly.