### PR TITLE
Allow use of JIT in more cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ include = [
 # Default features (std) are disabled so that the dependencies don't pull in the
 # standard library when the crate is compiled for no_std
 byteorder = { version = "1.2", default-features = false }
-log = {version = "0.4.21", default-features = false }
+log = { version = "0.4.21", default-features = false }
 combine = { version = "4.6", default-features = false }
 
 # Optional Dependencies when using the standard library
-libc = { version = "0.2", optional = true }
+region = { version = "3.0", optional = true }
 time = { version = "0.2", optional = true }
 
 # Optional Dependencies for the CraneLift JIT
@@ -50,7 +50,7 @@ hex = "0.4.3"
 
 [features]
 default = ["std"]
-std = ["dep:time", "dep:libc", "combine/std"]
+std = ["dep:time", "dep:region", "combine/std"]
 cranelift = [
     "dep:cranelift-codegen",
     "dep:cranelift-frontend",

--- a/README.md
+++ b/README.md
@@ -317,10 +317,10 @@ fn main() {
     // directly reads from packet data)
     let mut vm = rbpf::EbpfVmRaw::new(Some(prog)).unwrap();
 
-    #[cfg(any(windows, not(feature = "std")))] {
+    #[cfg(not(feature = "std"))] {
         assert_eq!(vm.execute_program(mem).unwrap(), 0x11);
     }
-    #[cfg(all(not(windows), feature = "std"))] {
+    #[cfg(feature = "std")] {
         // This time we JIT-compile the program.
         vm.jit_compile().unwrap();
 
@@ -363,10 +363,10 @@ fn main() {
     // This eBPF VM is for program that use a metadata buffer.
     let mut vm = rbpf::EbpfVmMbuff::new(Some(prog)).unwrap();
 
-    #[cfg(any(windows, not(feature = "std")))] {
+    #[cfg(not(feature = "std"))] {
         assert_eq!(vm.execute_program(mem, mbuff).unwrap(), 0x2211);
     }
-    #[cfg(all(not(windows), feature = "std"))] {
+    #[cfg(feature = "std")] {
         // Here again we JIT-compile the program.
         vm.jit_compile().unwrap();
 

--- a/examples/load_elf.rs
+++ b/examples/load_elf.rs
@@ -115,19 +115,9 @@ fn main() {
     println!("Packet #1, program returned: {res:?} ({res:#x})");
     assert_eq!(res, 0xffffffff);
 
-    #[cfg(not(windows))]
-    {
-        vm.jit_compile().unwrap();
+    vm.jit_compile().unwrap();
 
-        let res = unsafe { vm.execute_program_jit(packet2).unwrap() };
-        println!("Packet #2, program returned: {res:?} ({res:#x})");
-        assert_eq!(res, 0);
-    }
-
-    #[cfg(windows)]
-    {
-        let res = vm.execute_program(packet2).unwrap();
-        println!("Packet #2, program returned: {:?} ({:#x})", res, res);
-        assert_eq!(res, 0);
-    }
+    let res = unsafe { vm.execute_program_jit(packet2).unwrap() };
+    println!("Packet #2, program returned: {res:?} ({res:#x})");
+    assert_eq!(res, 0);
 }

--- a/examples/rbpf_plugin.rs
+++ b/examples/rbpf_plugin.rs
@@ -38,12 +38,12 @@ fn main() {
                 return;
             }
             "--jit" => {
-                #[cfg(any(windows, not(feature = "std")))]
+                #[cfg(not(feature = "std"))]
                 {
                     println!("JIT not supported");
                     return;
                 }
-                #[cfg(all(not(windows), feature = "std"))]
+                #[cfg(feature = "std")]
                 {
                     jit = true;
                 }
@@ -96,12 +96,12 @@ fn main() {
 
     let result: u64;
     if jit {
-        #[cfg(any(windows, not(feature = "std")))]
+        #[cfg(not(feature = "std"))]
         {
             println!("JIT not supported");
             return;
         }
-        #[cfg(all(not(windows), feature = "std"))]
+        #[cfg(feature = "std")]
         {
             unsafe {
                 vm.jit_compile().unwrap();

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -55,14 +55,14 @@ fn main() {
 
     let time;
 
-    #[cfg(all(not(windows), feature = "std"))]
+    #[cfg(feature = "std")]
     {
         vm.jit_compile().unwrap();
 
         time = unsafe { vm.execute_program_jit().unwrap() };
     }
 
-    #[cfg(any(windows, not(feature = "std")))]
+    #[cfg(not(feature = "std"))]
     {
         time = vm.execute_program().unwrap();
     }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7,7 +7,7 @@
 
 #![allow(clippy::single_match)]
 
-use crate::{ebpf, Error, ErrorKind, HashMap};
+use crate::{ebpf, format, vec, Error, ErrorKind, HashMap, Vec};
 use core::fmt::Error as FormatterError;
 use core::fmt::Formatter;
 use core::mem;

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -172,7 +172,7 @@ fn test_vm_block_port() {
 }
 
 #[test]
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 fn test_jit_block_port() {
     // To load the bytecode from an object file instead of using the hardcoded instructions,
     // use the additional crates commented at the beginning of this file (and also add them to your
@@ -320,7 +320,7 @@ fn test_vm_mbuff_with_rust_api() {
 
 // Program and memory come from uBPF test ldxh.
 #[test]
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 fn test_jit_mbuff() {
     #[rustfmt::skip]
     let prog = &[
@@ -347,7 +347,7 @@ fn test_jit_mbuff() {
     }
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 fn test_vm_jit_ldabsb() {
     #[rustfmt::skip]
@@ -369,7 +369,7 @@ fn test_vm_jit_ldabsb() {
     };
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 fn test_vm_jit_ldabsh() {
     #[rustfmt::skip]
@@ -391,7 +391,7 @@ fn test_vm_jit_ldabsh() {
     };
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 fn test_vm_jit_ldabsw() {
     #[rustfmt::skip]
@@ -413,7 +413,7 @@ fn test_vm_jit_ldabsw() {
     };
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 fn test_vm_jit_ldabsdw() {
     #[rustfmt::skip]
@@ -468,7 +468,7 @@ fn test_vm_err_ldabsb_nomem() {
     // Memory check not implemented for JIT yet.
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 fn test_vm_jit_ldindb() {
     #[rustfmt::skip]
@@ -491,7 +491,7 @@ fn test_vm_jit_ldindb() {
     };
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 fn test_vm_jit_ldindh() {
     #[rustfmt::skip]
@@ -514,7 +514,7 @@ fn test_vm_jit_ldindh() {
     };
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 fn test_vm_jit_ldindw() {
     #[rustfmt::skip]
@@ -537,7 +537,7 @@ fn test_vm_jit_ldindw() {
     };
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 fn test_vm_jit_ldinddw() {
     #[rustfmt::skip]
@@ -662,7 +662,7 @@ fn test_vm_bpf_to_bpf_call() {
     assert_eq!(vm_res, 0x10);
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 fn test_vm_jit_bpf_to_bpf_call() {
     let test_code = assemble(
@@ -715,7 +715,7 @@ fn test_vm_other_type_call() {
     vm.execute_program().unwrap();
 }
 
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(feature = "std")]
 #[test]
 #[should_panic(expected = "[JIT] Error: unexpected call type #2 (insn #0)")]
 fn test_vm_jit_other_type_call() {

--- a/tests/ubpf_jit_x86_64.rs
+++ b/tests/ubpf_jit_x86_64.rs
@@ -16,7 +16,7 @@
 
 // These are unit tests for the eBPF JIT compiler.
 
-#![cfg(all(not(windows), feature = "std"))]
+#![cfg(feature = "std")]
 
 extern crate rbpf;
 mod common;


### PR DESCRIPTION
- Remove JIT restrictions on Windows. Now, we will use the cross-platform library [region](https://crates.io/crates/region) to allocate executable memory.
- In order to allow the use of jit in no_std mode, it is necessary to let the user manually pass in the executable memory area.

Todo:
[ ] test on windows