### PR TITLE
feat: support JIT in no_std mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ include = [
 # Default features (std) are disabled so that the dependencies don't pull in the
 # standard library when the crate is compiled for no_std
 byteorder = { version = "1.2", default-features = false }
-log = {version = "0.4.21", default-features = false }
+log = { version = "0.4.21", default-features = false }
 combine = { version = "4.6", default-features = false }
 
 # Optional Dependencies when using the standard library


### PR DESCRIPTION
In order to allow the use of jit in no_std mode, it is necessary to let the user manually pass in the executable memory area.