### PR TITLE
README.md: Fix space (non-breaking space)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ checked with a very simple verifier (nothing close to the one for Linux
 kernel). Users are also able to replace it with a custom verifier.
 
 For `struct EbpfVmFixedMbuff`, two additional arguments must be passed to the
-constructor: `data_offset` and `data_end_offset`. They are the offset (byte
+constructor: `data_offset` and `data_end_offset`. They are the offset (byte
 number) at which the pointers to the beginning and to the end, respectively, of
 the memory area of packet data are to be stored in the internal metadata buffer
 each time the program is executed. Other structs do not use this mechanism and


### PR DESCRIPTION
Replace a non-breaking space (U+C2A0) with a normal space in the README.md. This non-ASCII character coming right after a preformatted argument name apparently cause rustc to panic:

    $ cargo +nightly clippy --all-features
    [...]

    thread 'rustc' panicked at compiler/rustc_resolve/src/rustdoc.rs:573:52:
    byte index 7115 is not a char boundary; it is inside '\u{a0}' (bytes 7114..7116) of `# rbpf

    <picture>
      <source media="(prefers-color-scheme: dark)" srcset="misc/rbpf_256_border.png">
      <img src="misc/rbpf_256.png">
    </picture>

    Rust (user-space) virtual machine for eBPF

    [![Build Status](https://github.com/qmonnet/rbpf/actions/workflows/t`[...]
    stack backtrace:

    [...]

    error: the compiler unexpectedly panicked. this is a bug.
    [...]

Link: https://github.com/qmonnet/rbpf/actions/runs/15249809389/job/42949036444?pr=125
