### PR TITLE
jit: Enable JIT without "std" feature, but with global alloc

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain: [stable, beta, nightly]
-        features: [--all-features]
+        features: [--features "std cranelift"]
         include:
           - toolchain: nightly
             features: --no-default-features
@@ -75,7 +75,8 @@ jobs:
 
       - name: Build plug-in
         run: |
-          cargo build --all-features --release --example rbpf_plugin
+          cargo build --no-default-features --features "std cranelift" --release --example rbpf_plugin
+          cargo build --no-default-features --features "alloc" --release --example rbpf_plugin_alloc
 
       - name: Run BPF conformance tests - Interpreter
         run: |
@@ -94,6 +95,15 @@ jobs:
           --plugin_path /rbpf/target/release/examples/rbpf_plugin \
           --exclude_regex "${{ env.KNOWN_FAILURES }}"  \
           --plugin_options "--jit" || true
+          
+      - name: Run BPF conformance tests Alloc feature - JIT
+        run: |
+          docker run -v ${{github.workspace}}:/rbpf --rm \
+          "${{ env.CONFORMANCE_IMAGE }}" \
+          bin/bpf_conformance_runner --test_file_directory tests \
+          --plugin_path /rbpf/target/release/examples/rbpf_plugin_alloc \
+          --exclude_regex "${{ env.KNOWN_FAILURES }}"  \
+          --plugin_options "--jit" || true          
 
       - name: Run BPF conformance tests - Cranelift
         run: |
@@ -111,7 +121,8 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          cargo llvm-cov --lcov --all --all-features --all-targets > lcov.info
+          cargo build --no-default-features --features "std cranelift" --release --example rbpf_plugin
+          cargo llvm-cov --no-default-features --features "alloc" --lcov --all --all-targets > lcov_alloc.info
 
       - name: Upload coverage to coveralls
         uses: coverallsapp/github-action@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ combine = { version = "4.6", default-features = false }
 libc = { version = "0.2", optional = true }
 time = { version = "0.2", optional = true }
 
+# Optional Dependencies for using alloc
+no-std-compat = {version = "0.4.1", optional = true }
+
 # Optional Dependencies for the CraneLift JIT
 cranelift-codegen = { version = "0.99", optional = true }
 cranelift-frontend = { version = "0.99", optional = true }
@@ -52,6 +55,7 @@ hex = "0.4.3"
 [features]
 default = ["std"]
 std = ["dep:time", "dep:libc", "combine/std"]
+alloc = ["dep:no-std-compat"]
 cranelift = [
     "dep:cranelift-codegen",
     "dep:cranelift-frontend",

--- a/README.md
+++ b/README.md
@@ -568,7 +568,10 @@ get more information and examples on how to use it.
 
 ## Build features
 
-### `no_std`
+> [!WARNING]
+> To rbpf developers: The `std` and `alloc` features are mutually exclusive. If you want to add [a feature](https://doc.rust-lang.org/cargo/reference/features.html) to this codebase you need to make sure to update the feature matrix in [the CI](https://github.com/qmonnet/rbpf/blob/main/.github/workflows/test.yaml#L21).
+
+### `std`
 
 The `rbpf` crate has a Cargo feature named "std" that is enabled by default. To
 use `rbpf` in `no_std` environments this feature needs to be disabled. To do
@@ -581,14 +584,24 @@ rbpf = { version = "0.3.0", default-features = false }
 ```
 
 Note that when using this crate in `no_std` environments, the `jit` module
-isn't available. This is because it depends on functions provided by `libc`
-(`libc::posix_memalign()`, `libc::mprotect()`) which aren't available on
-`no_std`.
+isn't available, unless the `alloc` feature is turned on. This is because
+it depends on allocation being memory aligned and a memory protection function
+provided by `libc` (`libc::mprotect()`) which isn't available on `no_std`.
 
 The `assembler` module is available, albeit with reduced debugging features. It
 depends on the `combine` crate providing parser combinators. Under `no_std`
 this crate only provides simple parsers which generate less descriptive error
 messages.
+
+### `alloc`
+
+The `rbpf` crate has a Cargo feature named "alloc" that is not enabled by
+default. `std` must be turned off and is mutually exclusive with alloc.
+When `alloc` is turned on the code importing rbpf must provide an
+implementation of the [`GlobalAlloc` trait](https://doc.rust-lang.org/beta/std/alloc/trait.GlobalAlloc.html).
+All JIT examples will work that do not require the "std" feature.
+The `time` and `rand` functions will not be available, for example.
+
 
 ## Feedback welcome!
 

--- a/examples/rbpf_plugin.rs
+++ b/examples/rbpf_plugin.rs
@@ -4,6 +4,12 @@
 // Path: examples/rbpf_plugin.rs
 use std::io::Read;
 
+#[cfg(all(not(windows), not(feature = "std"), feature = "alloc"))]
+use std::alloc::System;
+#[cfg(all(not(windows), not(feature = "std"), feature = "alloc"))]
+#[global_allocator]
+static GLOBAL: System = System;
+
 // Helper function used by https://github.com/Alan-Jowett/bpf_conformance/blob/main/tests/call_unwind_fail.data
 fn _unwind(a: u64, _b: u64, _c: u64, _d: u64, _e: u64) -> u64 {
     a
@@ -38,12 +44,12 @@ fn main() {
                 return;
             }
             "--jit" => {
-                #[cfg(any(windows, not(feature = "std")))]
+                #[cfg(not(any(feature = "std", feature = "alloc")))]
                 {
                     println!("JIT not supported");
                     return;
                 }
-                #[cfg(all(not(windows), feature = "std"))]
+                #[cfg(all(not(windows), any(feature = "std", feature = "alloc")))]
                 {
                     jit = true;
                 }
@@ -96,12 +102,12 @@ fn main() {
 
     let result: u64;
     if jit {
-        #[cfg(any(windows, not(feature = "std")))]
+        #[cfg(not(any(feature = "std", feature = "alloc")))]
         {
             println!("JIT not supported");
             return;
         }
-        #[cfg(all(not(windows), feature = "std"))]
+        #[cfg(all(not(windows), any(feature = "std", feature = "alloc")))]
         {
             unsafe {
                 vm.jit_compile().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 // Configures the crate to be `no_std` when `std` feature is disabled.
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(all(feature = "std", feature = "alloc"))]
+compile_error!("feature \"std\" and feature \"alloc\" cannot be enabled at the same time");
+
 extern crate byteorder;
 extern crate combine;
 extern crate log;
@@ -510,11 +513,11 @@ impl<'a> EbpfVmMbuff<'a> {
                 "Error: No program set, call prog_set() to load one",
             ))?,
         };
-        #[cfg(feature = "std")]
+        #[cfg(any(feature = "std", feature = "alloc"))]
         {
             self.jit = Some(jit::JitMemory::new(prog, &self.helpers, true, false)?);
         }
-        #[cfg(not(feature = "std"))]
+        #[cfg(not(any(feature = "std", feature = "alloc")))]
         {
             let exec_memory = match self.custom_exec_memory.take() {
                 Some(memory) => memory,
@@ -1141,11 +1144,11 @@ impl<'a> EbpfVmFixedMbuff<'a> {
                 "Error: No program set, call prog_set() to load one",
             ))?,
         };
-        #[cfg(feature = "std")]
+        #[cfg(any(feature = "std", feature = "alloc"))]
         {
             self.parent.jit = Some(jit::JitMemory::new(prog, &self.parent.helpers, true, true)?);
         }
-        #[cfg(not(feature = "std"))]
+        #[cfg(not(any(feature = "std", feature = "alloc")))]
         {
             let exec_memory = match self.parent.custom_exec_memory.take() {
                 Some(memory) => memory,
@@ -1661,7 +1664,7 @@ impl<'a> EbpfVmRaw<'a> {
                 "Error: No program set, call prog_set() to load one",
             ))?,
         };
-        #[cfg(feature = "std")]
+        #[cfg(any(feature = "std", feature = "alloc"))]
         {
             self.parent.jit = Some(jit::JitMemory::new(
                 prog,
@@ -1670,7 +1673,7 @@ impl<'a> EbpfVmRaw<'a> {
                 false,
             )?);
         }
-        #[cfg(not(feature = "std"))]
+        #[cfg(not(any(feature = "std", feature = "alloc")))]
         {
             let exec_memory = match self.parent.custom_exec_memory.take() {
                 Some(memory) => memory,


### PR DESCRIPTION
Add a new "alloc" feature that indicates that the crate importing rbpf has an implementation of the GlobalAlloc trait. Memory protection is ignored in the "no_std" environment.
