### PR TITLE
fix: upgraded json package dependency version from 0.11 to 0.12 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ hashbrown = { version = "0.15", default-features = false, features = ["default-h
 [dev-dependencies]
 libc = { version = "0.2" }
 elf = "0.0.10"
-json = "0.11"
+json = "0.12"
 hex = "0.4.3"
 
 [features]


### PR DESCRIPTION
I updated the package version for json in order to use the current stable json package release