### PR TITLE
Cargo.toml,README.md: Bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 # Project metadata
 name = "rbpf"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Quentin Monnet <qmo@qmon.net>"]
 
 # Additional metadata for packaging

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ file:
 
 ```toml
 [dependencies]
-rbpf = "0.3.0"
+rbpf = "0.4.0"
 ```
 
 You can also use the development version from this GitHub repository. This
@@ -388,7 +388,7 @@ to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-rbpf = "0.3.0"
+rbpf = "0.4.0"
 elf = "0.0.10"
 ```
 
@@ -581,7 +581,7 @@ enabled-by-default features.
 
 ```toml
 [dependencies]
-rbpf = { version = "0.3.0", default-features = false }
+rbpf = { version = "0.4.0", default-features = false }
 ```
 
 Note that when using this crate in `no_std` environments, the `jit` module


### PR DESCRIPTION
Main features since v0.3.0 include:

- Support for eBPF-to-eBPF function calls with automatic stack frame management, including:
  - stack frame context preservation during function calls
  - maximum nesting level of 8 function calls
  - customizable `StackUsageCalculator` for stack size optimization
  - support in both interpreter and JIT modes
  - assembler and disassembler support for eBPF call instructions

- JIT support in `no_std` mode - users can now manually provide executable memory areas to use JIT without requiring the standard library.

- Replacing single-byte address representation with `Range` type for memory access ranges, to reduce memory overhead for maps storing large amounts of data; and using the hashbrown crate for better `HashMap` performance in `no_std` mode.

- Reduced dependency on libc, obtained by replacing several calls with standard library alternatives:
  - Replaced `rand()` with a simple `Wyrand` implementation
  - Replaced `libc::memcpy` with `ptr::copy_nonoverlapping`
  - Replaced libc memory allocation with `std::alloc`
  Only `mprotect()` remains as a libc dependency.

- Bumping cargo edition to 2024

- Dependency updates, including:
  - replacing the deprecated time v0.2 crate with `std::time::Instant`, providing cross-platform monotonic time functionality using only the standard library
  - cranelift
  - elf (we were stuck with a very old version because newer versions had breaking changes; these changes have now been addressed)

- Various fixes and clean-ups

(These notes were mostly generated from the Git history by Claude Code.)
