### PR TITLE
fix: use is_reg for devisor in emit_muldivmod

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -433,7 +433,9 @@ impl JitCompiler {
         if dst != RDX {
             self.emit_push(mem, RDX);
         }
-        if imm != 0 {
+
+        // Load the divisor into RCX.
+        if !is_reg {
             self.emit_load_imm(mem, RCX, imm as i64);
         } else {
             self.emit_mov(mem, src, RCX);


### PR DESCRIPTION
should not use `ins.imm != 0` to  decide if it's a register operation

see: https://github.com/iovisor/ubpf/blob/d8af62f3a5f720d74a1d84ce6b94b86fb7c7cb10/vm/ubpf_jit_x86_64.c#L1299