### PR TITLE
feat: legacy XADD and correct JIT code buffer sizing

### DIFF
--- a/src/cranelift.rs
+++ b/src/cranelift.rs
@@ -5,8 +5,8 @@ use cranelift_codegen::{
     ir::{
         condcodes::IntCC,
         types::{I16, I32, I64, I8},
-        AbiParam, Block, Endianness, FuncRef, Function, InstBuilder, MemFlags, Signature,
-        SourceLoc, StackSlotData, StackSlotKind, TrapCode, Type, UserFuncName, Value,
+        AbiParam, AtomicRmwOp, Block, Endianness, FuncRef, Function, InstBuilder, MemFlags,
+        Signature, SourceLoc, StackSlotData, StackSlotKind, TrapCode, Type, UserFuncName, Value,
     },
     isa::OwnedTargetIsa,
     settings::{self, Configurable},
@@ -382,8 +382,16 @@ impl CraneliftCompiler {
                     self.reg_store(bcx, ty, base, insn.off, narrow);
                 }
 
-                ebpf::ST_W_XADD => unimplemented!(),
-                ebpf::ST_DW_XADD => unimplemented!(),
+                ebpf::ST_W_XADD => {
+                    let base = self.insn_dst(bcx, &insn);
+                    let val = self.insn_src32(bcx, &insn);
+                    self.reg_atomic_add(bcx, I32, base, insn.off, val);
+                }
+                ebpf::ST_DW_XADD => {
+                    let base = self.insn_dst(bcx, &insn);
+                    let val = self.insn_src(bcx, &insn);
+                    self.reg_atomic_add(bcx, I64, base, insn.off, val);
+                }
 
                 // BPF_ALU class
                 // TODO Check how overflow works in kernel. Should we &= U32MAX all src register value
@@ -999,6 +1007,25 @@ impl CraneliftCompiler {
         flags.set_endianness(Endianness::Little);
 
         bcx.ins().store(flags, val, base, offset as i32);
+    }
+
+    /// Legacy eBPF XADD: `*(ty *)(base + off) += val` (non-fetch).
+    fn reg_atomic_add(
+        &mut self,
+        bcx: &mut FunctionBuilder,
+        ty: Type,
+        base: Value,
+        offset: i16,
+        val: Value,
+    ) {
+        self.insert_bounds_check(bcx, ty, base, offset);
+        let mut flags = MemFlags::new();
+        flags.set_endianness(Endianness::Little);
+        let off = bcx.ins().iconst(self.isa.pointer_type(), offset as i64);
+        let addr = bcx.ins().iadd(base, off);
+        let _old = bcx
+            .ins()
+            .atomic_rmw(ty, flags, AtomicRmwOp::Add, addr, val);
     }
 
     /// Inserts a bounds check for a memory access

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -10,6 +10,9 @@ use crate::ebpf::MAX_CALL_DEPTH;
 use crate::lib::*;
 use crate::stack::{StackFrame, StackUsage};
 use core::ops::Range;
+#[cfg(target_has_atomic = "64")]
+use core::sync::atomic::AtomicU64;
+use core::sync::atomic::{AtomicU32, Ordering};
 
 #[allow(clippy::too_many_arguments)]
 fn check_mem(
@@ -254,8 +257,55 @@ pub fn execute_program(
                 check_mem_store(x as u64, 8, insn_ptr)?;
                 x.write_unaligned(reg[_src]);
             },
-            ebpf::ST_W_XADD  => Err(Error::other(format!("Error: XADD instructions are not supported (insn #{})", insn_ptr - 1)))?,
-            ebpf::ST_DW_XADD => Err(Error::other(format!("Error: XADD instructions are not supported (insn #{})", insn_ptr - 1)))?,
+            ebpf::ST_W_XADD  => unsafe {
+                // Semantics: *(u32 *)(dst + off) += (u32)src
+                let x = (reg[_dst] as *const u8).wrapping_offset(insn.off as isize) as *mut u32;
+                check_mem_store(x as u64, 4, insn_ptr)?;
+                let add = reg[_src] as u32;
+
+                let addr = x as usize;
+                if addr.is_multiple_of(core::mem::align_of::<u32>()) {
+                    // Safety: AtomicU32 has the same size/alignment as u32, and we enforce natural
+                    // alignment. The pointed memory is treated as atomic for the duration of the VM
+                    // execution.
+                    let a = x as *const AtomicU32;
+                    let _prev = (*a).fetch_add(add, Ordering::Relaxed);
+                } else {
+                    Err(Error::other(format!(
+                        "Error: unaligned atomic XADD (ST_W_XADD) (insn #{}), addr {:#x}, required alignment {}",
+                        insn_ptr - 1,
+                        x as u64,
+                        core::mem::align_of::<u32>()
+                    )))?;
+                }
+            },
+            #[cfg(target_has_atomic = "64")]
+            ebpf::ST_DW_XADD => unsafe {
+                // Semantics: *(u64 *)(dst + off) += src
+                let x = (reg[_dst] as *const u8).wrapping_offset(insn.off as isize) as *mut u64;
+                check_mem_store(x as u64, 8, insn_ptr)?;
+                let add = reg[_src];
+
+                let addr = x as usize;
+                if addr.is_multiple_of(core::mem::align_of::<u64>()) {
+                    // Safety: AtomicU64 has the same size/alignment as u64 on targets that provide
+                    // 64-bit atomics, and we enforce natural alignment.
+                    let a = x as *const AtomicU64;
+                    let _prev = (*a).fetch_add(add, Ordering::Relaxed);
+                } else {
+                    Err(Error::other(format!(
+                        "Error: unaligned atomic XADD (ST_DW_XADD) (insn #{}), addr {:#x}, required alignment {}",
+                        insn_ptr - 1,
+                        x as u64,
+                        core::mem::align_of::<u64>()
+                    )))?;
+                }
+            },
+            #[cfg(not(target_has_atomic = "64"))]
+            ebpf::ST_DW_XADD => Err(Error::other(format!(
+                "Error: atomic XADD (ST_DW_XADD) requires 64-bit atomics on this target (insn #{})",
+                insn_ptr - 1
+            )))?,
 
             // BPF_ALU class
             // TODO Check how overflow works in kernel. Should we &= U32MAX all src register value

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -19,9 +19,10 @@ use core::ptr;
 type MachineCode = unsafe fn(*mut u8, usize, *mut u8, usize, usize, usize) -> u64;
 
 const PAGE_SIZE: usize = 4096;
-// TODO: check how long the page must be to be sure to support an eBPF program of maximum possible
-// length
-const NUM_PAGES: usize = 1;
+
+fn round_up_to_page(size: usize) -> usize {
+    (size + PAGE_SIZE - 1) & !(PAGE_SIZE - 1)
+}
 
 // Special values for target_pc in struct Jump
 const TARGET_OFFSET: isize = ebpf::PROG_MAX_INSNS as isize;
@@ -79,10 +80,12 @@ fn map_register(r: u8) -> u8 {
 macro_rules! emit_bytes {
     ( $mem:ident, $data:tt, $t:ty ) => {{
         let size = mem::size_of::<$t>() as usize;
-        assert!($mem.offset + size <= $mem.contents.len());
-        unsafe {
-            let ptr = $mem.contents.as_ptr().add($mem.offset) as *mut $t;
-            ptr.write_unaligned($data);
+        if $mem.write_enabled {
+            assert!($mem.offset + size <= $mem.contents.len());
+            unsafe {
+                let ptr = $mem.contents.as_mut_ptr().add($mem.offset) as *mut $t;
+                ptr.write_unaligned($data);
+            }
         }
         $mem.offset += size;
     }};
@@ -1009,11 +1012,14 @@ impl JitCompiler {
             };
 
             // Assumes jump offset is at end of instruction
+            if !mem.write_enabled {
+                continue;
+            }
             unsafe {
                 let offset_loc = jump.offset_loc as i32 + core::mem::size_of::<i32>() as i32;
                 let rel = &(target_loc as i32 - offset_loc) as *const i32;
 
-                let offset_ptr = mem.contents.as_ptr().add(jump.offset_loc) as *mut u8;
+                let offset_ptr = mem.contents.as_mut_ptr().add(jump.offset_loc);
                 ptr::copy_nonoverlapping(rel.cast::<u8>(), offset_ptr, core::mem::size_of::<i32>());
             }
         }
@@ -1023,12 +1029,26 @@ impl JitCompiler {
 
 pub struct JitMemory<'a> {
     contents: &'a mut [u8],
+    write_enabled: bool,
     #[cfg(feature = "std")]
     layout: std::alloc::Layout,
     offset: usize,
 }
 
 impl<'a> JitMemory<'a> {
+    fn counter() -> JitMemory<'a> {
+        let contents: &'a mut [u8] = unsafe {
+            core::slice::from_raw_parts_mut(core::ptr::NonNull::<u8>::dangling().as_ptr(), 0)
+        };
+        JitMemory {
+            contents,
+            write_enabled: false,
+            #[cfg(feature = "std")]
+            layout: unsafe { std::alloc::Layout::from_size_align_unchecked(0, 1) },
+            offset: 0,
+        }
+    }
+
     #[cfg(feature = "std")]
     pub fn new(
         prog: &[u8],
@@ -1038,10 +1058,14 @@ impl<'a> JitMemory<'a> {
     ) -> Result<JitMemory<'a>, Error> {
         let layout;
 
-        // Allocate the appropriately sized memory.
+        // Pass 1: size-only, no writes.
+        let mut counter = JitMemory::counter();
+        let mut jit = JitCompiler::new();
+        jit.jit_compile(&mut counter, prog, use_mbuff, update_data_ptr, helpers)?;
+        let size = round_up_to_page(counter.offset.max(PAGE_SIZE));
+
         let contents = unsafe {
             // Create a layout with the proper size and alignment.
-            let size = NUM_PAGES * PAGE_SIZE;
             layout = std::alloc::Layout::from_size_align_unchecked(size, PAGE_SIZE);
 
             // Allocate the region of memory.
@@ -1056,13 +1080,16 @@ impl<'a> JitMemory<'a> {
             // Convert to a slice.
             std::slice::from_raw_parts_mut(ptr, size)
         };
+        let contents: &'a mut [u8] = unsafe { mem::transmute(contents) };
 
         let mut mem = JitMemory {
             contents,
+            write_enabled: true,
             layout,
             offset: 0,
         };
 
+        // Pass 2: real emission + reloc resolution.
         let mut jit = JitCompiler::new();
         jit.jit_compile(&mut mem, prog, use_mbuff, update_data_ptr, helpers)?;
         jit.resolve_jumps(&mut mem)?;
@@ -1078,8 +1105,14 @@ impl<'a> JitMemory<'a> {
         use_mbuff: bool,
         update_data_ptr: bool,
     ) -> Result<JitMemory<'a>, Error> {
+        // Pass 1: compute required size.
+        let mut counter = JitMemory::counter();
+        let mut jit = JitCompiler::new();
+        jit.jit_compile(&mut counter, prog, use_mbuff, update_data_ptr, helpers)?;
+        let size = round_up_to_page(counter.offset.max(PAGE_SIZE));
+
         let contents = executable_memory;
-        if contents.len() < NUM_PAGES * PAGE_SIZE {
+        if contents.len() < size {
             return Err(Error::new(
                 ErrorKind::Other,
                 "Executable memory is too small",
@@ -1094,9 +1127,11 @@ impl<'a> JitMemory<'a> {
 
         let mut mem = JitMemory {
             contents,
+            write_enabled: true,
             offset: 0,
         };
 
+        // Pass 2: real emission + reloc resolution.
         let mut jit = JitCompiler::new();
         jit.jit_compile(&mut mem, prog, use_mbuff, update_data_ptr, helpers)?;
         jit.resolve_jumps(&mut mem)?;
@@ -1127,7 +1162,9 @@ impl IndexMut<usize> for JitMemory<'_> {
 impl Drop for JitMemory<'_> {
     fn drop(&mut self) {
         unsafe {
-            std::alloc::dealloc(self.contents.as_mut_ptr(), self.layout);
+            if self.layout.size() > 0 {
+                std::alloc::dealloc(self.contents.as_mut_ptr(), self.layout);
+            }
         }
     }
 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -639,8 +639,22 @@ impl JitCompiler {
                     self.emit_store(mem, OperandSize::S32, src, dst, insn.off as i32),
                 ebpf::ST_DW_REG  =>
                     self.emit_store(mem, OperandSize::S64, src, dst, insn.off as i32),
-                ebpf::ST_W_XADD  => unimplemented!(),
-                ebpf::ST_DW_XADD => unimplemented!(),
+                ebpf::ST_W_XADD  => {
+                    // Semantics: *(u32 *)(dst + off) += (u32)src
+                    // JIT assumes effective address is naturally aligned.
+                    self.emit1(mem, 0xf0); // lock prefix
+                    self.emit_basic_rex(mem, 0, src, dst);
+                    self.emit1(mem, 0x01); // add r/m32, r32
+                    self.emit_modrm_and_displacement(mem, src, dst, insn.off as i32);
+                }
+                ebpf::ST_DW_XADD => {
+                    // Semantics: *(u64 *)(dst + off) += src
+                    // JIT assumes effective address is naturally aligned.
+                    self.emit1(mem, 0xf0); // lock prefix
+                    self.emit_basic_rex(mem, 1, src, dst);
+                    self.emit1(mem, 0x01); // add r/m64, r64
+                    self.emit_modrm_and_displacement(mem, src, dst, insn.off as i32);
+                }
 
                 // BPF_ALU class
                 ebpf::ADD32_IMM  => self.emit_alu32_imm32(mem, 0x81, 0, dst, insn.imm),

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -154,8 +154,23 @@ pub fn check(prog: &[u8]) -> Result<(), Error> {
             ebpf::ST_H_REG   => store = true,
             ebpf::ST_W_REG   => store = true,
             ebpf::ST_DW_REG  => store = true,
-            ebpf::ST_W_XADD  => { reject(format!("XADD instructions are not supported (insn #{insn_ptr:?})"))?; },
-            ebpf::ST_DW_XADD => { reject(format!("XADD instructions are not supported (insn #{insn_ptr:?})"))?; },
+            ebpf::ST_W_XADD  => {
+                // Same opcode as BPF atomic stores; legacy XADD uses imm == 0.
+                if insn.imm != 0 {
+                    reject(format!(
+                        "atomic operations other than legacy XADD are not supported (insn #{insn_ptr:?})"
+                    ))?;
+                }
+                store = true;
+            },
+            ebpf::ST_DW_XADD => {
+                if insn.imm != 0 {
+                    reject(format!(
+                        "atomic operations other than legacy XADD are not supported (insn #{insn_ptr:?})"
+                    ))?;
+                }
+                store = true;
+            },
 
             // BPF_ALU class
             ebpf::ADD32_IMM  => {},

--- a/tests/cranelift.rs
+++ b/tests/cranelift.rs
@@ -2285,3 +2285,44 @@ fn test_cranelift_ldinddw() {
         0xccbbaa9988776655
     );
 }
+
+#[test]
+fn test_cranelift_xadd_w() {
+    use rbpf::ebpf::{self, Insn};
+
+    let insns = [
+        Insn { opc: ebpf::MOV32_IMM, dst: 2, src: 0, off: 0, imm: 5 },
+        Insn { opc: ebpf::ST_W_XADD, dst: 1, src: 2, off: 0, imm: 0 },
+        Insn { opc: ebpf::LD_W_REG, dst: 0, src: 1, off: 0, imm: 0 },
+        Insn { opc: ebpf::EXIT, dst: 0, src: 0, off: 0, imm: 0 },
+    ];
+    let prog: Vec<u8> = insns.iter().flat_map(|i| i.to_array()).collect();
+
+    let mut mem = [0u8; 8];
+    mem[..4].copy_from_slice(&10u32.to_le_bytes());
+
+    let mut vm = rbpf::EbpfVmRaw::new(Some(&prog)).unwrap();
+    vm.cranelift_compile().unwrap();
+    assert_eq!(vm.execute_program_cranelift(&mut mem).unwrap(), 15);
+}
+
+#[cfg(target_has_atomic = "64")]
+#[test]
+fn test_cranelift_xadd_dw() {
+    use rbpf::ebpf::{self, Insn};
+
+    let insns = [
+        Insn { opc: ebpf::MOV64_IMM, dst: 2, src: 0, off: 0, imm: 7 },
+        Insn { opc: ebpf::ST_DW_XADD, dst: 1, src: 2, off: 0, imm: 0 },
+        Insn { opc: ebpf::LD_DW_REG, dst: 0, src: 1, off: 0, imm: 0 },
+        Insn { opc: ebpf::EXIT, dst: 0, src: 0, off: 0, imm: 0 },
+    ];
+    let prog: Vec<u8> = insns.iter().flat_map(|i| i.to_array()).collect();
+
+    let mut mem = [0u8; 16];
+    mem[..8].copy_from_slice(&10u64.to_le_bytes());
+
+    let mut vm = rbpf::EbpfVmRaw::new(Some(&prog)).unwrap();
+    vm.cranelift_compile().unwrap();
+    assert_eq!(vm.execute_program_cranelift(&mut mem).unwrap(), 17);
+}

--- a/tests/jit_sizing.rs
+++ b/tests/jit_sizing.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+extern crate rbpf;
+
+use rbpf::ebpf::{self, Insn};
+
+#[cfg(all(not(windows), not(feature = "std")))]
+fn alloc_exec_memory() -> Box<[u8]> {
+    let size = 4096;
+    let layout = std::alloc::Layout::from_size_align(size, 4096).unwrap();
+    unsafe {
+        let ptr = std::alloc::alloc(layout);
+        assert!(!ptr.is_null(), "Failed to allocate memory");
+
+        libc::mprotect(ptr.cast(), size, libc::PROT_EXEC | libc::PROT_WRITE);
+
+        let slice = std::slice::from_raw_parts_mut(ptr, size);
+        Box::from_raw(slice)
+    }
+}
+
+#[cfg(not(windows))]
+#[test]
+fn test_jit_dry_run_resolves_jumps() {
+    // Forward jump: dry-run sizing must walk resolve_jumps with write_enabled=false.
+    let insns = [
+        Insn { opc: ebpf::MOV32_IMM, dst: 0, src: 0, off: 0, imm: 1 },
+        Insn { opc: ebpf::JA,         dst: 0, src: 0, off: 1, imm: 0 },
+        Insn { opc: ebpf::MOV32_IMM, dst: 0, src: 0, off: 0, imm: 99 },
+        Insn { opc: ebpf::EXIT,      dst: 0, src: 0, off: 0, imm: 0 },
+    ];
+    let prog = insns.iter().flat_map(|i| i.to_array()).collect::<Vec<u8>>();
+
+    let mut mem = [0u8; 8];
+    let mut vm = rbpf::EbpfVmRaw::new(Some(&prog)).unwrap();
+    assert_eq!(vm.execute_program(&mut mem).unwrap(), 1);
+
+    #[cfg(not(feature = "std"))]
+    let mut exec_mem = alloc_exec_memory();
+    #[cfg(not(feature = "std"))]
+    vm.set_jit_exec_memory(&mut exec_mem).unwrap();
+    vm.jit_compile().unwrap();
+    unsafe {
+        assert_eq!(vm.execute_program_jit(&mut mem).unwrap(), 1);
+    }
+}

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -198,3 +198,16 @@ fn test_verifier_err_funcall_over_the_end() {
     let vm = rbpf::EbpfVmNoData::new(Some(prog)).unwrap();
     vm.execute_program().unwrap();
 }
+
+#[test]
+#[should_panic(expected = "[Verifier] Error: atomic operations other than legacy XADD are not supported (insn #0)")]
+fn test_verifier_err_atomic_fetch_add() {
+    // ST_W_XADD with imm = EBPF_ALU_OP_ADD | FETCH (newer atomic, not legacy XADD).
+    #[rustfmt::skip]
+    let prog = &[
+        0xc3, 0x21, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    let vm = rbpf::EbpfVmNoData::new(Some(prog)).unwrap();
+    vm.execute_program().unwrap();
+}

--- a/tests/xadd.rs
+++ b/tests/xadd.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+extern crate rbpf;
+
+use rbpf::ebpf::{self, Insn};
+
+#[cfg(all(not(windows), not(feature = "std")))]
+fn alloc_exec_memory() -> Box<[u8]> {
+    let size = 4096;
+    let layout = std::alloc::Layout::from_size_align(size, 4096).unwrap();
+    unsafe {
+        let ptr = std::alloc::alloc(layout);
+        assert!(!ptr.is_null(), "Failed to allocate memory");
+
+        libc::mprotect(ptr.cast(), size, libc::PROT_EXEC | libc::PROT_WRITE);
+
+        let slice = std::slice::from_raw_parts_mut(ptr, size);
+        Box::from_raw(slice)
+    }
+}
+
+#[test]
+fn test_interpreter_xadd_w() {
+    // r1 points to the provided memory buffer in EbpfVmRaw.
+    // *(u32 *)(r1 + 0) += 5
+    let insns = [
+        Insn { opc: ebpf::MOV32_IMM, dst: 2, src: 0, off: 0, imm: 5 },
+        Insn { opc: ebpf::ST_W_XADD, dst: 1, src: 2, off: 0, imm: 0 },
+        Insn { opc: ebpf::LD_W_REG,  dst: 0, src: 1, off: 0, imm: 0 },
+        Insn { opc: ebpf::EXIT,      dst: 0, src: 0, off: 0, imm: 0 },
+    ];
+    let prog = insns.iter().flat_map(|i| i.to_array()).collect::<Vec<u8>>();
+
+    let mut mem = [0u8; 8];
+    mem[..4].copy_from_slice(&10u32.to_le_bytes());
+
+    let vm = rbpf::EbpfVmRaw::new(Some(&prog)).unwrap();
+    assert_eq!(vm.execute_program(&mut mem).unwrap(), 15);
+}
+
+#[test]
+fn test_interpreter_xadd_w_unaligned() {
+    // *(u32 *)(r1 + 1) is not naturally aligned.
+    let insns = [
+        Insn { opc: ebpf::MOV32_IMM, dst: 2, src: 0, off: 0, imm: 5 },
+        Insn { opc: ebpf::ST_W_XADD, dst: 1, src: 2, off: 1, imm: 0 },
+        Insn { opc: ebpf::EXIT,      dst: 0, src: 0, off: 0, imm: 0 },
+    ];
+    let prog = insns.iter().flat_map(|i| i.to_array()).collect::<Vec<u8>>();
+
+    let mut mem = [0u8; 8];
+    mem[1..5].copy_from_slice(&42u32.to_le_bytes());
+    let initial = mem;
+
+    let vm = rbpf::EbpfVmRaw::new(Some(&prog)).unwrap();
+    let result = vm.execute_program(&mut mem);
+    assert!(result.is_err());
+    assert_eq!(mem, initial);
+    #[cfg(feature = "std")]
+    assert!(result.unwrap_err().to_string().contains("unaligned atomic XADD"));
+}
+
+#[cfg(target_has_atomic = "64")]
+#[test]
+fn test_interpreter_xadd_dw_unaligned() {
+    let insns = [
+        Insn { opc: ebpf::MOV64_IMM,  dst: 2, src: 0, off: 0, imm: 7 },
+        Insn { opc: ebpf::ST_DW_XADD, dst: 1, src: 2, off: 1, imm: 0 },
+        Insn { opc: ebpf::EXIT,       dst: 0, src: 0, off: 0, imm: 0 },
+    ];
+    let prog = insns.iter().flat_map(|i| i.to_array()).collect::<Vec<u8>>();
+
+    let mut mem = [0u8; 16];
+    mem[1..9].copy_from_slice(&42u64.to_le_bytes());
+    let initial = mem;
+
+    let vm = rbpf::EbpfVmRaw::new(Some(&prog)).unwrap();
+    let result = vm.execute_program(&mut mem);
+    assert!(result.is_err());
+    assert_eq!(mem, initial);
+    #[cfg(feature = "std")]
+    assert!(result.unwrap_err().to_string().contains("unaligned atomic XADD"));
+}
+
+#[cfg(target_has_atomic = "64")]
+#[test]
+fn test_interpreter_xadd_dw() {
+    // *(u64 *)(r1 + 0) += 7
+    let insns = [
+        Insn { opc: ebpf::MOV64_IMM,  dst: 2, src: 0, off: 0, imm: 7 },
+        Insn { opc: ebpf::ST_DW_XADD, dst: 1, src: 2, off: 0, imm: 0 },
+        Insn { opc: ebpf::LD_DW_REG,  dst: 0, src: 1, off: 0, imm: 0 },
+        Insn { opc: ebpf::EXIT,       dst: 0, src: 0, off: 0, imm: 0 },
+    ];
+    let prog = insns.iter().flat_map(|i| i.to_array()).collect::<Vec<u8>>();
+
+    let mut mem = [0u8; 16];
+    mem[..8].copy_from_slice(&10u64.to_le_bytes());
+
+    let vm = rbpf::EbpfVmRaw::new(Some(&prog)).unwrap();
+    assert_eq!(vm.execute_program(&mut mem).unwrap(), 17);
+}
+
+#[cfg(all(target_has_atomic = "64", target_arch = "x86_64", not(windows)))]
+#[test]
+fn test_jit_xadd_w_dw() {
+    // Run both instructions through JIT as well (x86_64 only).
+    let insns = [
+        Insn { opc: ebpf::MOV32_IMM,  dst: 2, src: 0, off: 0, imm: 5 },
+        Insn { opc: ebpf::ST_W_XADD,  dst: 1, src: 2, off: 0, imm: 0 },
+        Insn { opc: ebpf::MOV64_IMM,  dst: 2, src: 0, off: 0, imm: 7 },
+        Insn { opc: ebpf::ST_DW_XADD, dst: 1, src: 2, off: 8, imm: 0 },
+        Insn { opc: ebpf::LD_DW_REG,  dst: 0, src: 1, off: 8, imm: 0 },
+        Insn { opc: ebpf::EXIT,       dst: 0, src: 0, off: 0, imm: 0 },
+    ];
+    let prog = insns.iter().flat_map(|i| i.to_array()).collect::<Vec<u8>>();
+
+    let mut mem = [0u8; 32];
+    mem[..4].copy_from_slice(&10u32.to_le_bytes());
+    mem[8..16].copy_from_slice(&10u64.to_le_bytes());
+
+    let mut vm = rbpf::EbpfVmRaw::new(Some(&prog)).unwrap();
+    #[cfg(all(not(windows), not(feature = "std")))]
+    let mut exec_mem = alloc_exec_memory();
+    #[cfg(all(not(windows), not(feature = "std")))]
+    vm.set_jit_exec_memory(&mut exec_mem).unwrap();
+    vm.jit_compile().unwrap();
+    unsafe {
+        assert_eq!(vm.execute_program_jit(&mut mem).unwrap(), 17);
+    }
+    assert_eq!(u32::from_le_bytes(mem[..4].try_into().unwrap()), 15);
+}


### PR DESCRIPTION
Hi, and thanks for a great project.

I hit a wall: my program uses atomic operations and wouldn’t run- it was hitting unimplemented. After digging through the code, adding support for the legacy XADD instructions looked straightforward, so I went ahead and implemented it.

I might come back later with full atomic support, but for now I’d like to get this merged.

Thanks!